### PR TITLE
Add tests for qerrors module

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -134,3 +134,4 @@ async function qerrors(error, context, req, res, next) {
 } //
 
 module.exports = qerrors;
+module.exports.analyzeError = analyzeError; //exposing analyzeError for testing usage

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A middleware module to log errors and analyze them via an external AI API. Error logger that prints error stack and AI advice in the actual logs to resolve errors.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node -r ./setup.js --test"
   },
   "keywords": [
     "error",

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,3 @@
+const path = require('path');
+process.env.NODE_PATH = path.join(__dirname, 'stubs'); //add stub modules path
+require('module').Module._initPaths();

--- a/stubs/axios.js
+++ b/stubs/axios.js
@@ -1,0 +1,1 @@
+module.exports = { post: async () => ({}) };

--- a/stubs/winston.js
+++ b/stubs/winston.js
@@ -1,0 +1,15 @@
+module.exports = {
+  createLogger: () => ({ error: () => {}, warn: () => {}, info: () => {} }),
+  format: {
+    combine: () => {},
+    timestamp: () => {},
+    errors: () => {},
+    splat: () => {},
+    json: () => {},
+    printf: () => {}
+  },
+  transports: {
+    File: function(){},
+    Console: function(){}
+  }
+};

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const axios = require('axios');
+const qerrorsModule = require('../lib/qerrors');
+const { analyzeError } = qerrorsModule;
+
+const originalPost = axios.post;
+
+test('analyzeError handles AxiosError gracefully', async () => {
+  const err = new Error('axios fail');
+  err.name = 'AxiosError';
+  err.uniqueErrorName = 'AXERR';
+  const result = await analyzeError(err, 'ctx');
+  assert.equal(result, undefined);
+});
+
+test('analyzeError returns null without token', async () => {
+  delete process.env.OPENAI_TOKEN;
+  const err = new Error('no token');
+  err.uniqueErrorName = 'NOTOKEN';
+  const result = await analyzeError(err, 'ctx');
+  assert.equal(result, null);
+});
+
+test('analyzeError returns advice from api', async () => {
+  process.env.OPENAI_TOKEN = 't';
+  axios.post = async () => ({ data: { choices: [{ message: { content: { data: 'adv' } } }] } });
+  const err = new Error('test');
+  err.uniqueErrorName = 'OK';
+  const result = await analyzeError(err, 'ctx');
+  assert.deepEqual(result, { data: 'adv' });
+});
+
+test.after(() => {
+  axios.post = originalPost;
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,12 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const pkg = require('../index');
+const qerrors = require('../lib/qerrors');
+const logger = require('../lib/logger');
+
+test('index exports qerrors and logger', () => {
+  assert.equal(pkg.qerrors, qerrors);
+  assert.equal(pkg.logger, logger);
+  assert.equal(pkg.default, qerrors);
+});

--- a/test/qerrors.test.js
+++ b/test/qerrors.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const qerrors = require('../lib/qerrors');
+const logger = require('../lib/logger');
+
+const origLoggerError = logger.error;
+
+function createRes() {
+  return {
+    headersSent: false,
+    statusCode: null,
+    payload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.payload = data; return this; },
+    send(html) { this.payload = html; return this; }
+  };
+}
+
+test('qerrors logs and responds with json then calls next', async () => {
+  let logged;
+  logger.error = (err) => { logged = err; };
+  qerrors.analyzeError = async () => 'adv';
+  const res = createRes();
+  const req = { headers: {} };
+  const err = new Error('boom');
+  let nextArg;
+  const next = (e) => { nextArg = e; };
+  await qerrors(err, 'ctx', req, res, next);
+  assert.ok(err.uniqueErrorName);
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(res.payload.error.uniqueErrorName, err.uniqueErrorName);
+  assert.deepEqual(logged.uniqueErrorName, err.uniqueErrorName);
+  assert.equal(nextArg, err);
+});
+
+test('qerrors sends html when accept header requests it', async () => {
+  logger.error = () => {};
+  qerrors.analyzeError = async () => {};
+  const res = createRes();
+  const req = { headers: { accept: 'text/html' } };
+  const err = new Error('boom');
+  await qerrors(err, 'ctx', req, res);
+  assert.equal(res.statusCode, 500);
+  assert.ok(typeof res.payload === 'string');
+});
+
+test('qerrors does nothing when headers already sent', async () => {
+  logger.error = () => {};
+  qerrors.analyzeError = async () => {};
+  const res = createRes();
+  res.headersSent = true;
+  const err = new Error('boom');
+  let nextCalled = false;
+  await qerrors(err, 'ctx', {}, res, () => { nextCalled = true; });
+  assert.equal(res.statusCode, null);
+  assert.equal(nextCalled, false);
+});
+
+test('qerrors exits if no error provided', async () => {
+  let warned = false;
+  const origWarn = console.warn;
+  console.warn = () => { warned = true; };
+  await qerrors(null, 'ctx');
+  assert.equal(warned, true);
+  console.warn = origWarn;
+});
+
+test.after(() => {
+  logger.error = origLoggerError;
+});


### PR DESCRIPTION
## Summary
- expose `analyzeError` for testing
- add node test runner setup and stub modules
- create unit tests for error analysis and middleware
- verify index exports

## Testing
- `npm test`