### PR TITLE
Add extended test coverage

### DIFF
--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -32,6 +32,15 @@ test('analyzeError returns advice from api', async () => {
   assert.deepEqual(result, { data: 'adv' });
 });
 
+test('analyzeError handles non-object advice as null', async () => {
+  process.env.OPENAI_TOKEN = 't';
+  axios.post = async () => ({ data: { choices: [{ message: { content: 'adv' } }] } });
+  const err = new Error('test2');
+  err.uniqueErrorName = 'NOOBJ';
+  const result = await analyzeError(err, 'ctx');
+  assert.equal(result, null);
+});
+
 test.after(() => {
   axios.post = originalPost;
 });

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const logger = require('../lib/logger');
+
+test('logger exposes standard logging methods', () => {
+  assert.equal(typeof logger.error, 'function');
+  assert.equal(typeof logger.warn, 'function');
+  assert.equal(typeof logger.info, 'function');
+});
+

--- a/test/qerrors.test.js
+++ b/test/qerrors.test.js
@@ -57,6 +57,25 @@ test('qerrors does nothing when headers already sent', async () => {
   assert.equal(nextCalled, false);
 });
 
+test('qerrors handles absence of req res and next', async () => {
+  let logged;
+  logger.error = (err) => { logged = err; };
+  qerrors.analyzeError = async () => {};
+  const err = new Error('boom');
+  await qerrors(err);
+  assert.ok(err.uniqueErrorName);
+  assert.equal(logged.context, 'unknown context');
+});
+
+test('qerrors calls next without res', async () => {
+  logger.error = () => {};
+  qerrors.analyzeError = async () => {};
+  const err = new Error('boom');
+  let nextArg;
+  await qerrors(err, 'ctx', undefined, undefined, (e) => { nextArg = e; });
+  assert.equal(nextArg, err);
+});
+
 test('qerrors exits if no error provided', async () => {
   let warned = false;
   const origWarn = console.warn;


### PR DESCRIPTION
## Summary
- extend coverage for analyzeError edge cases
- test qerrors without req/res/next and ensure next called when res missing
- add tests for logger

## Testing
- `npm test --silent`