### PR TITLE
Update tests with stubMethod helper

### DIFF
--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -2,13 +2,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const axios = require('axios');
+const stubMethod = require('./utils/stubMethod'); //(import stubMethod util)
 const qerrorsModule = require('../lib/qerrors');
 const { analyzeError } = qerrorsModule;
 
-function stubAxiosPost(fn) { //(create swapper for axios.post)
-  const orig = axios.post; //(capture original)
-  axios.post = fn; //(apply stub)
-  return () => { axios.post = orig; }; //(return restore)
+function stubAxiosPost(fn) { //(wrap stubMethod for axios.post)
+  return stubMethod(axios, 'post', fn); //(delegate to stubMethod)
 }
 
 function withOpenAIToken(token) { //(temporarily set OPENAI_TOKEN)

--- a/test/utils/stubMethod.js
+++ b/test/utils/stubMethod.js
@@ -1,0 +1,7 @@
+function stubMethod(obj, method, fn) {
+  const orig = obj[method]; //(capture original method)
+  obj[method] = fn; //(replace with stub)
+  return () => { obj[method] = orig; }; //(return restore function)
+}
+
+module.exports = stubMethod; //(export stubMethod)


### PR DESCRIPTION
## Summary
- introduce `test/utils/stubMethod.js`
- refactor `stubAxiosPost` in `analyzeError.test.js` to use `stubMethod`

## Testing
- `npm test`