### PR TITLE
Use stubMethod helper in tests

### DIFF
--- a/test/qerrors.test.js
+++ b/test/qerrors.test.js
@@ -3,17 +3,14 @@ const assert = require('node:assert/strict');
 
 const qerrors = require('../lib/qerrors');
 const logger = require('../lib/logger');
+const stubMethod = require('./utils/stubMethod'); //import generic stubbing helper
 
 function stubLogger(mock) { //helper to stub logger.error and return restore function
-  const orig = logger.error; //store original method for later restore
-  logger.error = mock; //replace logger.error with provided mock
-  return () => { logger.error = orig; }; //return restore function
+  return stubMethod(logger, 'error', mock); //use stubMethod to replace logger.error
 }
 
 function stubAnalyzeError(mock) { //helper to stub analyzeError and return restore
-  const orig = qerrors.analyzeError; //store original function
-  qerrors.analyzeError = mock; //replace analyzeError with mock
-  return () => { qerrors.analyzeError = orig; }; //return restore function
+  return stubMethod(qerrors, 'analyzeError', mock); //use stubMethod to replace analyzeError
 }
 
 function createRes() {

--- a/test/utils/stubMethod.js
+++ b/test/utils/stubMethod.js
@@ -1,0 +1,7 @@
+function stubMethod(obj, method, mock) {
+  const orig = obj[method]; //capture original method for restore
+  obj[method] = mock; //apply provided mock
+  return () => { obj[method] = orig; }; //return restore function
+}
+
+module.exports = stubMethod;


### PR DESCRIPTION
## Summary
- add shared test utility `stubMethod`
- refactor logger and analyzeError stubs in `qerrors.test.js`

## Testing
- `npm test`