### PR TITLE
Fix analyzeError axios return

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -31,15 +31,15 @@ const axios = require('axios');
  * 
  * @param {Error} error - The error object containing name, message, and stack trace
  * @param {string} context - Contextual information about where/when the error occurred
- * @returns {Promise<Object|null>} - AI-generated advice object or null if analysis fails
+ * @returns {Promise<Object|null>} - AI-generated advice object or null if analysis fails or is skipped for Axios errors //(update return description)
  */
 async function analyzeError(error, context) {
 	// Prevent infinite loops by avoiding analysis of network errors from our own API calls
 	// This is critical because axios errors during AI analysis would trigger more analysis
-	if (error.name.includes("AxiosError")) {
-		console.log("Axios Error");
-		return
-	};
+        if (error.name.includes("AxiosError")) {
+                console.log("Axios Error"); //(log axios issue and skip API call)
+                return null; //(return null instead of undefined when skipping)
+        };
 	
 	// Log analysis attempt for debugging and tracking purposes
 	// Multi-line format improves readability in console output

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -28,7 +28,7 @@ test('analyzeError handles AxiosError gracefully', async () => {
   err.name = 'AxiosError';
   err.uniqueErrorName = 'AXERR';
   const result = await analyzeError(err, 'ctx');
-  assert.equal(result, undefined);
+  assert.equal(result, null); //(expect null when axios error is skipped)
 });
 
 test('analyzeError returns null without token', async () => {


### PR DESCRIPTION
## Summary
- tweak analyzeError to return `null` when an AxiosError occurs
- document the new return behavior
- update tests for the `null` AxiosError return

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a055b36dc832294bd66815d1c1fcd