### PR TITLE
Add rationale comment for logger export

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const logger = require('./lib/logger');
 
 // Primary export object - allows destructuring imports like { qerrors, logger }
 // This pattern provides clear, explicit imports while keeping related functionality grouped
-module.exports = {
+module.exports = { //exposes logger with qerrors so consumers use the same configured logger
   qerrors,
   logger
 };


### PR DESCRIPTION
## Summary
- document why we export logger along with qerrors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a0e54ff688322b9aac1cea411b401