### PR TITLE
Fix analyzeError OpenAI response handling

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -74,7 +74,7 @@ async function analyzeError(error, context) {
         const response = await axios.post('https://api.openai.com/v1/chat/completions', { //single API request to OpenAI service
 		model: 'gpt-4.1', // Latest model for best analysis quality
 		messages: [{role: 'user',	content: errorPrompt}],
-		response_format: {"type": "text"}, // Ensures plain text response suitable for logging
+		response_format: {"type": "json_object"}, // request structured JSON response from API // (changed from text to json_object to match object expectation)
 		temperature: 1, // High creativity for diverse debugging approaches
                 max_tokens: 2048, //changed property name per updated API requirement; still limits advice length
 		top_p: 1, // Full vocabulary access for technical terminology
@@ -89,7 +89,7 @@ async function analyzeError(error, context) {
 	
 	// Extract advice with fallback for API response failures
 	// Default message ensures function always returns something useful
-        const advice = response.data.choices[0].message.content || "No response received from API"; //extract first choice or fallback text
+        const advice = response?.data?.choices?.[0]?.message?.content || null; //safely access advice from api response // (added optional chaining)
 	
 	// Validate response structure and handle different API response formats
 	// This defensive programming handles potential API changes or unexpected responses
@@ -111,7 +111,7 @@ async function analyzeError(error, context) {
 	} else {
 		// Log analysis failure for debugging and monitoring
 		// Provides enough detail to diagnose API issues without exposing sensitive data
-		console.log(`Problem in analyzeError function of qerrors for ${error.uniqueErrorName}:', ${error.message}`);
+                console.log(`Problem in analyzeError function of qerrors for ${error.uniqueErrorName}: ${error.message}`); // (removed stray quote in log)
 		return null; // Graceful failure allows application to continue
 	}
 }


### PR DESCRIPTION
## Summary
- request structured JSON from OpenAI in `analyzeError`
- guard against missing response data
- clean up console log typo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a40b6d38483229f4940d557e1fdcf