### PR TITLE
Fix analyzeError logging

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -111,14 +111,14 @@ async function analyzeError(error, context) {
 				with context: "${context}"`);
 		
 		// Handle structured response with data property
-		if (advice.data) {
-			console.log(error.uniqueErrorName + " " + advice.data);
-			return advice;
-		} else if (advice) {
-			// Handle direct advice object
-			console.log(error.uniqueErrorName + " " + advice);
-			return advice;
-		}
+                if (advice.data) {
+                        console.log(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
+                        return advice;
+                } else if (advice) {
+                        // Handle direct advice object
+                        console.log(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
+                        return advice;
+                }
 	} else {
 		// Log analysis failure for debugging and monitoring
 		// Provides enough detail to diagnose API issues without exposing sensitive data


### PR DESCRIPTION
## Summary
- improve advice logging by stringifying objects before output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683bcd9999c483228093f8dc577d9c85