### PR TITLE
Fix package versions mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qerrors",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "qerrors",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.9.0",


### PR DESCRIPTION
## Summary
- sync versions in `package.json` and `package-lock.json`
- run tests

## Testing
- `npm test` *(fails: Cannot find module 'qtests', Cannot find module 'winston')*

------
https://chatgpt.com/codex/tasks/task_b_68433bdb800c8322b07820c028a89c02