### PR TITLE
Fix tests with qtests stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A middleware module to log errors and analyze them via an external AI API. Error logger that prints error stack and AI advice in the actual logs to resolve errors.",
   "main": "index.js",
   "scripts": {
-    "test": "node --test"
+    "test": "node -r ./setup.js --test"
   },
   "keywords": [
     "error",

--- a/setup.js
+++ b/setup.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const Module = require('module');
+const stubsPath = path.join(__dirname, 'stubs');
+process.env.NODE_PATH = process.env.NODE_PATH
+  ? `${stubsPath}${path.delimiter}${process.env.NODE_PATH}`
+  : stubsPath;
+Module._initPaths();

--- a/stubs/axios.js
+++ b/stubs/axios.js
@@ -1,0 +1,3 @@
+module.exports = {
+  post: async () => { throw new Error('axios.post not stubbed'); }
+};

--- a/stubs/qtests.js
+++ b/stubs/qtests.js
@@ -1,0 +1,7 @@
+module.exports.stubMethod = function(obj, method, impl) {
+  const original = obj[method];
+  obj[method] = impl;
+  return function restore() {
+    obj[method] = original;
+  };
+};

--- a/stubs/winston.js
+++ b/stubs/winston.js
@@ -1,0 +1,16 @@
+function dummy() { return () => {}; }
+const format = {
+  combine: (...args) => ({ combine: args }),
+  timestamp: dummy,
+  errors: dummy,
+  splat: dummy,
+  json: dummy,
+  printf: (fn) => fn
+};
+class File { constructor() {} }
+class Console { constructor() {} }
+module.exports = {
+  createLogger: () => ({ error() {}, warn() {}, info() {} }),
+  format,
+  transports: { File, Console }
+};


### PR DESCRIPTION
## Summary
- enable offline stubs by adding `setup.js` and stub modules
- hook tests through `package.json` to preload the stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68433bb6320883228f666ede94dfb996