### PR TITLE
Fix OPENAI token restore in integration test

### DIFF
--- a/test/integration.qerrors.test.js
+++ b/test/integration.qerrors.test.js
@@ -22,6 +22,7 @@ test('qerrors integration logs error and analyzes context', async () => {
   let logArg; //capture logger.error argument
   const origLog = logger.error; //store original function
   logger.error = (...args) => { logArg = args[0]; return origLog.apply(logger, args); }; //wrap logger.error to capture call //(wrap to spy while preserving)
+  const origToken = process.env.OPENAI_TOKEN; //store token to restore after test
   process.env.OPENAI_TOKEN = 'tkn'; //set token for analyzeError to run
   const res = createRes(); //create mock res
   const err = new Error('boom'); //sample error
@@ -30,6 +31,7 @@ test('qerrors integration logs error and analyzes context', async () => {
   } finally {
     restoreAxios(); //restore axios.post
     logger.error = origLog; //restore logger.error
+    if (origToken === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = origToken; } //restore token after test
   }
   assert.ok(logArg.uniqueErrorName); //ensure log contains id
   assert.equal(logArg.uniqueErrorName, err.uniqueErrorName); //id matches error


### PR DESCRIPTION
## Summary
- capture the prior OPENAI_TOKEN value in `integration.qerrors.test.js`
- restore the token in the `finally` block after running qerrors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684358443d988322b70551be8ed25026