### PR TITLE
Implement advice caching

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -12,10 +12,15 @@
  * - Supports both Express middleware usage and standalone error handling
  */
 
+
 'use strict'; //(enable strict mode for improved error detection)
 
 const logger = require('./logger'); //centralized winston logger configuration
 const axios = require('axios'); //HTTP client used for OpenAI API calls
+const crypto = require('crypto'); //node crypto for hashing cache keys
+
+const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
+const adviceCache = new Map(); //Map used for LRU cache implementation
 
 function escapeHtml(str) { //escape characters for safe html insertion
         return String(str).replace(/[&<>"]/g, (ch) => { //(replace &,<,>," with entities)
@@ -52,19 +57,29 @@ async function analyzeError(error, context) {
                 console.log(`Axios Error`); //(log axios detection for analysis skip)
                 return null; //(avoid API call when axios error encountered)
         };
-	
-	// Log analysis attempt for debugging and tracking purposes
+
+        // Log analysis attempt for debugging and tracking purposes
 	// Multi-line format improves readability in console output
 	console.log(`qerrors error analysis is running for
 			error name: "${error.uniqueErrorName}",
 			error message: "${error.message}", 
-			with context: "${context}"`);
-	
-	// Graceful degradation when API token is not available
-	// Returns null rather than throwing to maintain application stability
-	if (!process.env.OPENAI_TOKEN) {
-		console.error("Missing OPENAI_TOKEN in environment variables.");
-		return null;
+                        with context: "${context}"`);
+
+        const key = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //hash message and stack for caching
+
+        if (adviceCache.has(key)) { //return cached advice when available
+                const cached = adviceCache.get(key); //retrieve cached entry
+                adviceCache.delete(key); //move to most recent for LRU
+                adviceCache.set(key, cached); //reinsert to maintain order
+                console.log(`cache hit for ${error.uniqueErrorName}`); //log cache usage
+                return cached; //skip api call when advice cached
+        }
+
+        // Graceful degradation when API token is not available
+        // Returns null rather than throwing to maintain application stability
+        if (!process.env.OPENAI_TOKEN) {
+                console.error("Missing OPENAI_TOKEN in environment variables.");
+                return null;
 	}
 	
 	// Carefully crafted prompt that optimizes for practical debugging advice
@@ -123,10 +138,14 @@ async function analyzeError(error, context) {
 		// Handle structured response with data property
                 if (advice.data) {
                         console.log(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
+                        adviceCache.set(key, advice); //store new advice in cache
+                        if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
                         return advice;
                 } else if (advice) {
                         // Handle direct advice object
                         console.log(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
+                        adviceCache.set(key, advice); //cache direct advice
+                        if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
                         return advice;
                 }
 	} else {


### PR DESCRIPTION
## Summary
- implement Map-based LRU cache for OpenAI advice
- avoid API calls when cached advice is present
- test repeated calls to confirm caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68436031e0108322b66a9943cef11cb9