### PR TITLE
Run error analysis after sending response

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -214,17 +214,7 @@ async function qerrors(error, context, req, res, next) {
 	// Uses structured logging format compatible with log aggregation systems
 	logger.error(errorLog);
 	
-        // Perform AI analysis asynchronously
-        // Await ensures analysis completes before response generation
-        // This provides the most complete information to developers
-        try { //start try to capture analyzeError failures
-                await analyzeError(error, context); //call AI analysis and wait for advice
-        } catch (analysisErr) { //catch analyzeError failures
-                logger.error(analysisErr); //log analyzeError failure without recursion
-        }
-	
-	// Completion logging for process tracking and debugging
-	console.log(`qerrors ran`);
+
 	
 	// HTTP response handling - only if Express response object is available
 	// Check headersSent prevents "Cannot set headers after they are sent" errors
@@ -268,11 +258,17 @@ async function qerrors(error, context, req, res, next) {
 	// Express middleware chain continuation
 	// Only call next if headers haven't been sent to prevent response conflicts
 	// This maintains Express middleware contract while preventing double responses
-	if (next) {
-		if (!res || !res.headersSent) {
-			next(error); // Pass error to next middleware for additional processing
-		}
-	}
+        if (next) {
+                if (!res || !res.headersSent) {
+                        next(error); // Pass error to next middleware for additional processing
+                }
+        }
+
+        Promise.resolve() //start async analysis without blocking response
+                .then(() => analyzeError(error, context)) //invoke AI analysis after sending response
+                .catch((analysisErr) => logger.error(analysisErr)); //log any analyzeError failures
+
+        console.log(`qerrors ran`); //log completion after scheduling analysis
 }
 
 // Export main qerrors function as default export


### PR DESCRIPTION
## Summary
- run `analyzeError` after sending the HTTP response
- log any async errors from `analyzeError`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68436031e23c8322bc4fdd6a30a86ea4