### PR TITLE
Add log rotation

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,6 +15,7 @@
  */
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
+const rotationOpts = { maxsize: 1024 * 1024, maxFiles: 5, tailable: true }; //(rotate logs at 1MB, keep 5 files)
 
 /**
  * Winston logger instance with multi-format, multi-transport configuration
@@ -70,11 +71,11 @@ const logger = createLogger({
 	transports: [
 		// Error-only file transport for focused error analysis and monitoring
 		// Separate file makes error tracking and alerting more efficient
-		new transports.File({ filename: 'error.log', level: 'error' }),
+               new transports.File({ filename: 'error.log', level: 'error', ...rotationOpts }), //(rotate error log when size limit hit)
 		
 		// Combined log file for comprehensive audit trail
 		// Includes all log levels for complete application behavior tracking
-		new transports.File({ filename: 'combined.log' }),
+               new transports.File({ filename: 'combined.log', ...rotationOpts }), //(rotate combined log using same options)
 		
 		// Console transport for immediate feedback during development
 		// Also useful for containerized deployments where logs go to stdout


### PR DESCRIPTION
## Summary
- ensure Winston rotates error and combined logs to avoid oversized files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684360339d3483229b5a542be72b6cfc