### PR TITLE
Truncate error stack before generating prompt

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -67,10 +67,11 @@ async function analyzeError(error, context) {
 		return null;
 	}
 	
-	// Carefully crafted prompt that optimizes for practical debugging advice
-	// Specific instructions prevent unhelpful generic responses and formatting issues
-	// Context inclusion helps AI understand the error's environment
-	const errorPrompt = `Analyze this error (${error.name}) that gave this message (${error.message}) and provide suggestions to fix it:\n\n${error.stack} 
+        // Carefully crafted prompt that optimizes for practical debugging advice
+        // Specific instructions prevent unhelpful generic responses and formatting issues
+        // Context inclusion helps AI understand the error's environment
+        const truncatedStack = (error.stack || '').split('\n').slice(0, 20).join('\n'); // (limit stack trace to 20 lines for smaller payloads)
+        const errorPrompt = `Analyze this error (${error.name}) that gave this message (${error.message}) and provide suggestions to fix it:\n\n${truncatedStack}
 	that happened in this context: ${context}. In your response, realize this is 
 	being printed to console logging, so do not include punctuation or symbols 
 	aimed at embedding or formatting such as quotation marks or markdown that will not work in an app's logging. 


### PR DESCRIPTION
## Summary
- reduce payload size in `analyzeError` by truncating stack traces to 20 lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843603307ec8322ab9283afc1dd76ac