### PR TITLE
Use axios instance with keep alive

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -17,10 +17,17 @@
 
 const logger = require('./logger'); //centralized winston logger configuration
 const axios = require('axios'); //HTTP client used for OpenAI API calls
+const http = require('http'); //node http for agent keep alive
+const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 
 const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
 const adviceCache = new Map(); //Map used for LRU cache implementation
+
+const axiosInstance = axios.create({ //axios instance with keep alive agents
+        httpAgent: new http.Agent({ keepAlive: true }), //reuse http connections
+        httpsAgent: new https.Agent({ keepAlive: true }) //reuse https connections
+});
 
 function escapeHtml(str) { //escape characters for safe html insertion
         return String(str).replace(/[&<>"]/g, (ch) => { //(replace &,<,>," with entities)
@@ -97,7 +104,7 @@ async function analyzeError(error, context) {
 	// OpenAI API call with optimized parameters for error analysis
 	// Model choice balances capability with cost and response time
 	// Parameters tuned for creative but focused debugging suggestions
-  const response = await axios.post('https://api.openai.com/v1/chat/completions', { //single API request to OpenAI service
+  const response = await axiosInstance.post('https://api.openai.com/v1/chat/completions', { //single API request to OpenAI service
 		model: 'gpt-4.1', // Latest model for best analysis quality
 		messages: [{role: 'user',	content: errorPrompt}],
 		response_format: {"type": "json_object"}, // request structured JSON response from API // (changed from text to json_object to match object expectation)
@@ -299,3 +306,4 @@ module.exports = qerrors;
 // This allows unit testing of the AI analysis functionality in isolation
 // Also enables advanced users to call error analysis without full qerrors processing
 module.exports.analyzeError = analyzeError;
+module.exports.axiosInstance = axiosInstance; //export axios instance for testing

--- a/stubs/axios.js
+++ b/stubs/axios.js
@@ -1,3 +1,8 @@
+function stubPost() { //default unmocked post throws to catch stray calls
+  throw new Error('axios.post not stubbed');
+}
+
 module.exports = {
-  post: async () => { throw new Error('axios.post not stubbed'); }
+  post: async () => { stubPost(); },
+  create: () => ({ post: async () => { stubPost(); } }) //mimic axios.create returning instance with post
 };

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -3,9 +3,9 @@ const test = require('node:test'); //node builtin test runner
 const assert = require('node:assert/strict'); //strict assertions for reliability
 const qtests = require('qtests'); //qtests stubbing utilities
 
-const axios = require('axios'); //axios module for stubbing
 const qerrorsModule = require('../lib/qerrors'); //import module under test
 const { analyzeError } = qerrorsModule; //extract analyzeError for direct calls
+const { axiosInstance } = qerrorsModule; //instance used inside analyzeError
 
 
 function withOpenAIToken(token) { //(temporarily set OPENAI_TOKEN)
@@ -24,8 +24,8 @@ function withOpenAIToken(token) { //(temporarily set OPENAI_TOKEN)
   };
 }
 
-function stubAxiosPost(content, capture) { //(capture axios.post args and stub response)
-  return qtests.stubMethod(axios, 'post', async (url, body) => { //(store url and body for assertions)
+function stubAxiosPost(content, capture) { //(capture axiosInstance.post args and stub response)
+  return qtests.stubMethod(axiosInstance, 'post', async (url, body) => { //(store url and body for assertions)
     capture.url = url; //(save called url)
     capture.body = body; //(save called body)
     return { data: { choices: [{ message: { content } }] } }; //(return predictable api response)
@@ -105,7 +105,7 @@ test('analyzeError returns cached advice on repeat call', async () => {
     assert.equal(first.advice, 'cached');
     restoreAxios(); //(remove first stub)
     let secondCalled = false; //(track second axios call)
-    const restoreAxios2 = qtests.stubMethod(axios, 'post', async () => { secondCalled = true; return {}; });
+    const restoreAxios2 = qtests.stubMethod(axiosInstance, 'post', async () => { secondCalled = true; return {}; });
     const err2 = new Error('cache me');
     err2.stack = 'stack';
     err2.uniqueErrorName = 'CACHE2';

--- a/test/integration.qerrors.test.js
+++ b/test/integration.qerrors.test.js
@@ -1,9 +1,9 @@
 const test = require('node:test'); //node test runner
 const assert = require('node:assert/strict'); //strict assertions
 const qtests = require('qtests'); //stubbing utilities
-const axios = require('axios'); //axios for stubbed network call
 
 const qerrors = require('../lib/qerrors'); //module under test
+const { axiosInstance } = qerrors; //axios instance used by qerrors
 const logger = require('../lib/logger'); //logger instance
 
 function createRes() { //minimal express like response mock
@@ -18,7 +18,7 @@ function createRes() { //minimal express like response mock
 }
 
 test('qerrors integration logs error and analyzes context', async () => {
-  const restoreAxios = qtests.stubMethod(axios, 'post', async () => ({ data: { choices: [{ message: { content: '{"ok":true}' } }] } })); //stub axios.post
+  const restoreAxios = qtests.stubMethod(axiosInstance, 'post', async () => ({ data: { choices: [{ message: { content: '{"ok":true}' } }] } })); //stub axiosInstance.post
   let logArg; //capture logger.error argument
   const origLog = logger.error; //store original function
   logger.error = (...args) => { logArg = args[0]; return origLog.apply(logger, args); }; //wrap logger.error to capture call //(wrap to spy while preserving)


### PR DESCRIPTION
## Summary
- create axios instance using keepAlive agents
- call axiosInstance.post instead of axios.post
- export axiosInstance for tests
- adjust axios stub for axios.create
- update tests to stub the new instance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684362e9a02c8322bc3b5f5ec2c8de74