### PR TITLE
Limit analyzeError concurrency with queue

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -21,6 +21,21 @@ const crypto = require('crypto'); //node crypto for hashing cache keys
 
 const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
 const adviceCache = new Map(); //Map used for LRU cache implementation
+const MAX_ANALYZE_CONCURRENT = 2; //max simultaneous analyzeError calls //(add limit for concurrent AI requests)
+const analysisQueue = []; //array storing queued analyze calls //(queue to hold waiting callers)
+let runningAnalyses = 0; //count currently running analyzeError calls //(tracking active analyses)
+
+async function acquireAnalysisSlot() { //await available slot before making API call
+        if (runningAnalyses < MAX_ANALYZE_CONCURRENT) { runningAnalyses++; return; }; //increment if slot free
+        await new Promise((resolve) => analysisQueue.push(resolve)); //queue resolver when limit reached
+        runningAnalyses++; //increment after dequeued
+}
+
+function releaseAnalysisSlot() { //free slot and process next queued call
+        runningAnalyses--; //decrement active count
+        const next = analysisQueue.shift(); //get next waiting resolver
+        if (next) { next(); }; //allow next analyzeError to run
+}
 
 function escapeHtml(str) { //escape characters for safe html insertion
         return String(str).replace(/[&<>"]/g, (ch) => { //(replace &,<,>," with entities)
@@ -94,9 +109,12 @@ async function analyzeError(error, context) {
 	"test the fix"; the dev knows the basics of their job, advise on the error 
 	and only the error. Do not use blank lines.`;
 	
-	// OpenAI API call with optimized parameters for error analysis
-	// Model choice balances capability with cost and response time
-	// Parameters tuned for creative but focused debugging suggestions
+        // OpenAI API call with optimized parameters for error analysis
+        // Model choice balances capability with cost and response time
+        // Parameters tuned for creative but focused debugging suggestions
+        await acquireAnalysisSlot(); //wait for an open slot before contacting API
+        let advice; //variable to hold parsed advice
+        try { //wrap api interaction in try/finally to always free queue slot
   const response = await axios.post('https://api.openai.com/v1/chat/completions', { //single API request to OpenAI service
 		model: 'gpt-4.1', // Latest model for best analysis quality
 		messages: [{role: 'user',	content: errorPrompt}],
@@ -115,7 +133,7 @@ async function analyzeError(error, context) {
 	
 	// Extract advice with fallback for API response failures
 	// Default message ensures function always returns something useful
-        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture raw advice which may be JSON string
+        advice = response?.data?.choices?.[0]?.message?.content || null; //capture raw advice which may be JSON string
 
         // OpenAI returns advice as a JSON string when using the json_object format
         // Attempt to parse it so the rest of the function works with an object
@@ -149,12 +167,15 @@ async function analyzeError(error, context) {
                         if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
                         return advice;
                 }
-	} else {
-		// Log analysis failure for debugging and monitoring
-		// Provides enough detail to diagnose API issues without exposing sensitive data
+        } else {
+                // Log analysis failure for debugging and monitoring
+                // Provides enough detail to diagnose API issues without exposing sensitive data
                 console.log(`Problem in analyzeError function of qerrors for ${error.uniqueErrorName}: ${error.message}`); // (removed stray quote in log)
-		return null; // Graceful failure allows application to continue
-	}
+                return null; // Graceful failure allows application to continue
+        }
+        } finally {
+                releaseAnalysisSlot(); //ensure next queued analysis can run
+        }
 }
 
 /**


### PR DESCRIPTION
## Summary
- limit concurrent analyzeError API calls with a queue
- wait for a slot before calling OpenAI and release slot when done
- test queue behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684362f792688322821168c6a7a65246