### PR TITLE
Refactor advice handling to use axios JSON parsing

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -122,18 +122,7 @@ async function analyzeError(error, context) {
 	
 	// Extract advice with fallback for API response failures
 	// Default message ensures function always returns something useful
-        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture raw advice which may be JSON string
-
-        // OpenAI returns advice as a JSON string when using the json_object format
-        // Attempt to parse it so the rest of the function works with an object
-        if (typeof advice === 'string') {
-                try {
-                        advice = JSON.parse(advice); //convert JSON string to object for easier handling
-                } catch (parseErr) {
-                        console.log(`Problem parsing advice JSON for ${error.uniqueErrorName}`); //log parse issue without throwing
-                        advice = null; //gracefully fall back to null to maintain function contract
-                }
-        }
+        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture structured advice object returned by OpenAI
 	
 	// Validate response structure and handle different API response formats
 	// This defensive programming handles potential API changes or unexpected responses

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -28,7 +28,7 @@ function stubAxiosPost(content, capture) { //(capture axiosInstance.post args an
   return qtests.stubMethod(axiosInstance, 'post', async (url, body) => { //(store url and body for assertions)
     capture.url = url; //(save called url)
     capture.body = body; //(save called body)
-    return { data: { choices: [{ message: { content } }] } }; //(return predictable api response)
+    return { data: { choices: [{ message: { content } }] } }; //(return predictable api response as object)
   });
 }
 
@@ -58,7 +58,7 @@ test('analyzeError returns null without token', async () => {
 test('analyzeError processes JSON response from API', async () => {
   const restoreToken = withOpenAIToken('test-token'); //(set valid token)
   const capture = {}; //(object to collect axios call args)
-  const restoreAxios = stubAxiosPost('{"advice": "test advice"}', capture); //(stub axios and capture arguments)
+  const restoreAxios = stubAxiosPost({ advice: 'test advice' }, capture); //(stub axios and capture arguments with object)
   try {
     const err = new Error('test error');
     err.uniqueErrorName = 'TESTERR';
@@ -96,7 +96,7 @@ test('analyzeError handles JSON parse errors', async () => {
 test('analyzeError returns cached advice on repeat call', async () => {
   const restoreToken = withOpenAIToken('cache-token'); //(set token for analysis)
   const capture = {}; //(capture axios parameters)
-  const restoreAxios = stubAxiosPost('{"advice":"cached"}', capture); //(first api response)
+  const restoreAxios = stubAxiosPost({ advice: 'cached' }, capture); //(first api response as object)
   try {
     const err = new Error('cache me');
     err.stack = 'stack';

--- a/test/integration.qerrors.test.js
+++ b/test/integration.qerrors.test.js
@@ -18,7 +18,7 @@ function createRes() { //minimal express like response mock
 }
 
 test('qerrors integration logs error and analyzes context', async () => {
-  const restoreAxios = qtests.stubMethod(axiosInstance, 'post', async () => ({ data: { choices: [{ message: { content: '{"ok":true}' } }] } })); //stub axiosInstance.post
+  const restoreAxios = qtests.stubMethod(axiosInstance, 'post', async () => ({ data: { choices: [{ message: { content: { ok: true } } }] } })); //stub axiosInstance.post with object content
   let logArg; //capture logger.error argument
   const origLog = logger.error; //store original function
   logger.error = (...args) => { logArg = args[0]; return origLog.apply(logger, args); }; //wrap logger.error to capture call //(wrap to spy while preserving)


### PR DESCRIPTION
## Summary
- remove manual JSON.parse step in `analyzeError`
- adapt tests for advice objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68436c6c50348322b598153d0bde5c50