### PR TITLE
Implement reuseable qerrorsKey

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -72,12 +72,14 @@ async function analyzeError(error, context) {
 			error message: "${error.message}", 
                         with context: "${context}"`);
 
-        const key = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //hash message and stack for caching
+        if (!error.qerrorsKey) { //check for existing qerrorsKey on error object
+                error.qerrorsKey = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //hash message and stack for caching
+        }
 
-        if (adviceCache.has(key)) { //return cached advice when available
-                const cached = adviceCache.get(key); //retrieve cached entry
-                adviceCache.delete(key); //move to most recent for LRU
-                adviceCache.set(key, cached); //reinsert to maintain order
+        if (adviceCache.has(error.qerrorsKey)) { //return cached advice when available
+                const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry
+                adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
+                adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
                 console.log(`cache hit for ${error.uniqueErrorName}`); //log cache usage
                 return cached; //skip api call when advice cached
         }
@@ -146,13 +148,13 @@ async function analyzeError(error, context) {
 		// Handle structured response with data property
                 if (advice.data) {
                         console.log(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
-                        adviceCache.set(key, advice); //store new advice in cache
+                        adviceCache.set(error.qerrorsKey, advice); //store new advice in cache
                         if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
                         return advice;
                 } else if (advice) {
                         // Handle direct advice object
                         console.log(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
-                        adviceCache.set(key, advice); //cache direct advice
+                        adviceCache.set(error.qerrorsKey, advice); //cache direct advice
                         if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
                         return advice;
                 }


### PR DESCRIPTION
## Summary
- cache key generation moved to `error.qerrorsKey` and reused
- update tests for key reuse

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68436c59be248322bd0610f85a8e558d