### PR TITLE
Use crypto randomUUID for qerrors IDs

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -20,6 +20,7 @@ const axios = require('axios'); //HTTP client used for OpenAI API calls
 const http = require('http'); //node http for agent keep alive
 const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
+const { randomUUID } = require('crypto'); //import UUID generator for unique names
 
 const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
 const adviceCache = new Map(); //Map used for LRU cache implementation
@@ -190,7 +191,7 @@ async function qerrors(error, context, req, res, next) {
 	// Generate unique error identifier for tracking and correlation
 	// Format: "ERROR: " + errorType + timestamp + randomString
 	// This allows linking related log entries and tracking error resolution
-        const uniqueErrorName = "ERROR: "+ error.name + "_" + Date.now() + "_" + Math.random().toString(36).slice(2); //generate reproducible identifier
+        const uniqueErrorName = `ERROR:${error.name}_${randomUUID()}`; //generate identifier via crypto uuid
 	
 	// Log error processing start with full context
 	// Multi-line format improves readability in log aggregation systems


### PR DESCRIPTION
## Summary
- import `randomUUID` for ID creation
- generate unique IDs with `randomUUID`

## Testing
- `npm test` *(fails: Cannot read properties of null (reading 'info'))*

------
https://chatgpt.com/codex/tasks/task_b_6843701ca1a0832281f1f05dae29fef2