### PR TITLE
Implement analysis queue

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -29,6 +29,16 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
         httpsAgent: new https.Agent({ keepAlive: true }) //reuse https connections
 });
 
+let active = 0; //count of active analyses to limit concurrency
+const limit = 5; //maximum analyses allowed at once
+
+async function scheduleAnalysis(err, ctx) { //queue analyzeError to avoid API flood
+        while (active >= limit) await new Promise(r => setTimeout(r, 50)); //wait until below limit
+        active++; //increment active count when slot available
+        try { return await analyzeError(err, ctx); } //perform analysis when slot free
+        finally { active--; } //decrement active count after analysis
+}
+
 function escapeHtml(str) { //escape characters for safe html insertion
         return String(str).replace(/[&<>"]/g, (ch) => { //(replace &,<,>," with entities)
                 if (ch === '&') { return '&amp;'; }
@@ -283,8 +293,8 @@ async function qerrors(error, context, req, res, next) {
         }
 
         Promise.resolve() //start async analysis without blocking response
-                .then(() => analyzeError(error, context)) //invoke AI analysis after sending response
-                .catch((analysisErr) => logger.error(analysisErr)); //log any analyzeError failures
+                .then(() => scheduleAnalysis(error, context)) //invoke queued analysis after sending response
+                .catch((analysisErr) => logger.error(analysisErr)); //log any scheduleAnalysis failures
 
         console.log(`qerrors ran`); //log completion after scheduling analysis
 }


### PR DESCRIPTION
## Summary
- add a small analysis queue with `scheduleAnalysis`
- queue `analyzeError` calls to avoid flooding the API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68436fc8048c83228e470dba9ccb61ca