### PR TITLE
Add configurable cache limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ to resolve errors.
 ## Environment Variables
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
+You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; the default is 50.
 
 ## License
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -22,7 +22,7 @@ const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 const { randomUUID } = require('crypto'); //import UUID generator for unique names
 
-const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
+const ADVICE_CACHE_LIMIT = Number(process.env.QERRORS_CACHE_LIMIT) || 50; //read cache size from env or default 50
 const adviceCache = new Map(); //Map used for LRU cache implementation
 
 const axiosInstance = axios.create({ //axios instance with keep alive agents
@@ -135,7 +135,12 @@ async function analyzeError(error, context) {
 	
 	// Extract advice with fallback for API response failures
 	// Default message ensures function always returns something useful
-        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture structured advice object returned by OpenAI
+        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture raw advice which may be JSON string
+
+        if (typeof advice === 'string') { //parse string response into object
+                try { advice = JSON.parse(advice); } //convert JSON string to object
+                catch { advice = null; } //ignore parse errors and fall back to null
+        }
 	
 	// Validate response structure and handle different API response formats
 	// This defensive programming handles potential API changes or unexpected responses


### PR DESCRIPTION
## Summary
- allow configuring the advice cache via `QERRORS_CACHE_LIMIT`
- parse OpenAI responses when they come as JSON strings
- document cache limit environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684373285b1483229440160b1ac1f556