### PR TITLE
Add env config for log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ to resolve errors.
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
 
+Additional options control the logger's file rotation:
+
+* `QERRORS_LOG_MAXSIZE` - max log file size in bytes before rotation (default `1048576`)
+* `QERRORS_LOG_MAXFILES` - number of rotated files to keep (default `5`)
+
 ## License
 
 ISC

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,7 +15,9 @@
  */
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
-const rotationOpts = { maxsize: 1024 * 1024, maxFiles: 5, tailable: true }; //(rotate logs at 1MB, keep 5 files)
+const logMaxSize = parseInt(process.env.QERRORS_LOG_MAXSIZE, 10) || 1024 * 1024; //(load max size from env or default to 1MB)
+const logMaxFiles = parseInt(process.env.QERRORS_LOG_MAXFILES, 10) || 5; //(load file count from env or default to 5)
+const rotationOpts = { maxsize: logMaxSize, maxFiles: logMaxFiles, tailable: true }; //(use env config when rotating logs)
 
 /**
  * Winston logger instance with multi-format, multi-transport configuration


### PR DESCRIPTION
## Summary
- let `lib/logger.js` read `QERRORS_LOG_MAXSIZE` and `QERRORS_LOG_MAXFILES`
- document log rotation options in the README

## Testing
- `npm test` *(fails: analyzeError reuses error.qerrorsKey when present)*

------
https://chatgpt.com/codex/tasks/task_b_68437380f6e483228dcf0f7cc378ca69