### PR TITLE
Use p-limit queue for analysis

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -21,6 +21,7 @@ const http = require('http'); //node http for agent keep alive
 const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 const { randomUUID } = require('crypto'); //import UUID generator for unique names
+const pLimit = require('p-limit'); //lightweight promise queue for concurrency control
 
 const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
 const adviceCache = new Map(); //Map used for LRU cache implementation
@@ -30,14 +31,11 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
         httpsAgent: new https.Agent({ keepAlive: true }) //reuse https connections
 });
 
-let active = 0; //count of active analyses to limit concurrency
 const limit = 5; //maximum analyses allowed at once
+const queue = pLimit(limit); //queue with concurrency limit
 
-async function scheduleAnalysis(err, ctx) { //queue analyzeError to avoid API flood
-        while (active >= limit) await new Promise(r => setTimeout(r, 50)); //wait until below limit
-        active++; //increment active count when slot available
-        try { return await analyzeError(err, ctx); } //perform analysis when slot free
-        finally { active--; } //decrement active count after analysis
+function scheduleAnalysis(err, ctx) { //queue analyzeError using p-limit
+        return queue(() => analyzeError(err, ctx)); //return queued promise for analysis
 }
 
 function escapeHtml(str) { //escape characters for safe html insertion
@@ -136,6 +134,9 @@ async function analyzeError(error, context) {
 	// Extract advice with fallback for API response failures
 	// Default message ensures function always returns something useful
         let advice = response?.data?.choices?.[0]?.message?.content || null; //capture structured advice object returned by OpenAI
+        if (advice && typeof advice === 'string') { //attempt to parse json string responses
+                try { advice = JSON.parse(advice); } catch { advice = null; } //parse or null on failure
+        }
 	
 	// Validate response structure and handle different API response formats
 	// This defensive programming handles potential API changes or unexpected responses

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "axios": "^1.9.0",
     "qtests": "^1.0.0",
-    "winston": "^3.13.0"
+    "winston": "^3.13.0",
+    "p-limit": "^4.0.0"
   },
   "directories": {
     "lib": "lib"

--- a/stubs/p-limit.js
+++ b/stubs/p-limit.js
@@ -1,0 +1,14 @@
+module.exports = function(limit){
+  let active=0;
+  const queue=[];
+  const next=()=>{
+    if(active>=limit||queue.length===0) return;
+    const {fn,resolve,reject}=queue.shift();
+    active++; //increase active count for concurrency limit
+    Promise.resolve().then(fn).then((val)=>{ active--; resolve(val); next(); }).catch((err)=>{ active--; reject(err); next(); });
+  };
+  return (fn)=>{
+    return new Promise((resolve,reject)=>{ queue.push({fn,resolve,reject}); next(); });
+  };
+};
+

--- a/test/integration.qerrors.test.js
+++ b/test/integration.qerrors.test.js
@@ -28,6 +28,7 @@ test('qerrors integration logs error and analyzes context', async () => {
   const err = new Error('boom'); //sample error
   try {
     await qerrors(err, 'spyCtx', {}, res); //invoke qerrors real functions
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis to finish
   } finally {
     restoreAxios(); //restore axios.post
     logger.error = origLog; //restore logger.error

--- a/test/qerrors.test.js
+++ b/test/qerrors.test.js
@@ -38,6 +38,7 @@ test('qerrors logs and responds with json then calls next', async () => {
   const next = (e) => { nextArg = e; }; //spy for next()
   try {
     await qerrors(err, 'ctx', req, res, next);
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore all stubs after test
   }
@@ -56,6 +57,7 @@ test('qerrors sends html when accept header requests it', async () => {
   const err = new Error('boom'); //sample error to send
   try {
     await qerrors(err, 'ctx', req, res);
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore all stubs after test
   }
@@ -72,6 +74,7 @@ test('qerrors escapes html content', async () => {
   err.stack = '<script>stack</script>'; //custom stack with html
   try {
     await qerrors(err, 'ctx', req, res);
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore stubs after test
   }
@@ -88,6 +91,7 @@ test('qerrors honors error.statusCode in json', async () => {
   err.statusCode = 404; //status code to verify
   try {
     await qerrors(err, 'ctx', req, res); //invoke handler with status
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore stubs after test
   }
@@ -104,6 +108,7 @@ test('qerrors honors error.statusCode in html', async () => {
   err.statusCode = 404; //status code to verify
   try {
     await qerrors(err, 'ctx', req, res); //invoke handler with status and html
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore stubs after test
   }
@@ -120,6 +125,7 @@ test('qerrors does nothing when headers already sent', async () => {
   let nextCalled = false; //track if next() invoked
   try {
     await qerrors(err, 'ctx', {}, res, () => { nextCalled = true; });
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore all stubs after test
   }
@@ -134,6 +140,7 @@ test('qerrors handles absence of req res and next', async () => {
   const err = new Error('boom'); //error for generic usage
   try {
     await qerrors(err);
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore all stubs after test
   }
@@ -148,6 +155,7 @@ test('qerrors calls next without res', async () => {
   let nextArg; //captured arg for next()
   try {
     await qerrors(err, 'ctx', undefined, undefined, (e) => { nextArg = e; });
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
   } finally {
     restore(); //restore all stubs after test
   }
@@ -161,6 +169,7 @@ test('qerrors exits if no error provided', async () => {
   const restoreWarn = qtests.stubMethod(console, 'warn', () => { warned = true; }); //use qtests to stub console.warn
   try {
     await qerrors(null, 'ctx');
+    await new Promise(r => setTimeout(r, 0)); //wait for queued analysis completion
     assert.equal(warned, true);
   } finally {
     restoreWarn(); //restore console.warn after test


### PR DESCRIPTION
## Summary
- manage analysis concurrency via `p-limit`
- parse JSON advice strings in `analyzeError`
- update integration and unit tests to wait for queued work
- add a stub for `p-limit` to keep tests offline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843731303f48322ad47d2d259d00e55