### PR TITLE
Make concurrency env-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ to resolve errors.
 
 ## Environment Variables
 
-You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
+You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com). //env variable for OpenAI access
+Set QERRORS_CONCURRENCY to adjust how many analyses run simultaneously; //new variable controlling concurrency
+if not set the default limit is 5. //explain fallback value
 
 ## License
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -31,7 +31,7 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 });
 
 let active = 0; //count of active analyses to limit concurrency
-const limit = 5; //maximum analyses allowed at once
+const limit = parseInt(process.env.QERRORS_CONCURRENCY, 10) || 5; //set concurrency from env var or default to 5
 
 async function scheduleAnalysis(err, ctx) { //queue analyzeError to avoid API flood
         while (active >= limit) await new Promise(r => setTimeout(r, 50)); //wait until below limit
@@ -133,9 +133,13 @@ async function analyzeError(error, context) {
 		}
 	});
 	
-	// Extract advice with fallback for API response failures
-	// Default message ensures function always returns something useful
+        // Extract advice with fallback for API response failures
+        // Default message ensures function always returns something useful
         let advice = response?.data?.choices?.[0]?.message?.content || null; //capture structured advice object returned by OpenAI
+        if (advice && typeof advice === 'string') { //parse json string from API if needed
+                try { advice = JSON.parse(advice); } //attempt parse when content string
+                catch { advice = null; } //null advice on parse failure
+        }
 	
 	// Validate response structure and handle different API response formats
 	// This defensive programming handles potential API changes or unexpected responses


### PR DESCRIPTION
## Summary
- allow qerrors to configure concurrency via `QERRORS_CONCURRENCY`
- document new environment variable
- parse JSON string replies in `analyzeError`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684372fe13608322ba3da1767a25a594