### PR TITLE
Add env config defaults with queue and retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ to resolve errors.
 
 ## Environment Variables
 
-You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
+qerrors reads several environment variables to tune its behavior. A small configuration file in the library sets sensible defaults when these variables are not defined. Only `OPENAI_TOKEN` must be provided manually to enable AI analysis.
+
+* `OPENAI_TOKEN` &ndash; your OpenAI API key.
+* `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`).
+* `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`).
+* `QERRORS_RETRIES` &ndash; attempts when calling OpenAI (default `3`).
+* `QERRORS_RETRY_DELAY_MS` &ndash; base delay in ms for retries (default `500`).
+* `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
+* `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
+* `QERRORS_VERBOSE` &ndash; enable console logging (`true` by default).
 
 ## License
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,19 @@
+'use strict'; //(enable strict mode for defaults module)
+
+const defaults = { //default environment variable values
+  QERRORS_CONCURRENCY: '5', //max concurrent analyses
+  QERRORS_CACHE_LIMIT: '50', //LRU cache size
+  QERRORS_RETRIES: '3', //number of API retries
+  QERRORS_RETRY_DELAY_MS: '500', //base delay for retries
+  QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
+  QERRORS_LOG_MAXFILES: '5', //number of rotated log files
+  QERRORS_VERBOSE: 'true' //enable verbose console logs
+};
+
+for (const key in defaults) { //iterate through defaults
+  if (!process.env[key]) { //assign when variable undefined
+    process.env[key] = defaults[key]; //set environment variable to default
+  }
+}
+
+module.exports = defaults; //export defaults for external use

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,7 +15,8 @@
  */
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
-const rotationOpts = { maxsize: 1024 * 1024, maxFiles: 5, tailable: true }; //(rotate logs at 1MB, keep 5 files)
+require('./config'); //ensure environment defaults are loaded
+const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //log rotation from env
 
 /**
  * Winston logger instance with multi-format, multi-transport configuration

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -14,6 +14,7 @@
 
 
 'use strict'; //(enable strict mode for improved error detection)
+require('./config'); //load default environment variables
 
 const logger = require('./logger'); //centralized winston logger configuration
 const axios = require('axios'); //HTTP client used for OpenAI API calls
@@ -22,7 +23,14 @@ const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 const { randomUUID } = require('crypto'); //import UUID generator for unique names
 
-const ADVICE_CACHE_LIMIT = 50; //max cache entries to limit memory growth
+function verboseLog(msg) { //conditional console output helper
+        if (process.env.QERRORS_VERBOSE === 'true') console.log(msg); //only log when enabled
+}
+
+const RETRIES = Number(process.env.QERRORS_RETRIES) || 3; //retry attempts count
+const RETRY_DELAY = Number(process.env.QERRORS_RETRY_DELAY_MS) || 500; //initial backoff delay
+
+const ADVICE_CACHE_LIMIT = Number(process.env.QERRORS_CACHE_LIMIT) || 50; //max cache entries configurable by env
 const adviceCache = new Map(); //Map used for LRU cache implementation
 
 const axiosInstance = axios.create({ //axios instance with keep alive agents
@@ -31,13 +39,24 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 });
 
 let active = 0; //count of active analyses to limit concurrency
-const limit = 5; //maximum analyses allowed at once
+const limit = Number(process.env.QERRORS_CONCURRENCY) || 5; //max analyses from env
+const queue = []; //pending analyses waiting for free slot
 
-async function scheduleAnalysis(err, ctx) { //queue analyzeError to avoid API flood
-        while (active >= limit) await new Promise(r => setTimeout(r, 50)); //wait until below limit
-        active++; //increment active count when slot available
-        try { return await analyzeError(err, ctx); } //perform analysis when slot free
-        finally { active--; } //decrement active count after analysis
+function processQueue() { //start next queued analysis if capacity
+        if (active >= limit || queue.length === 0) return; //exit if busy or none queued
+        const job = queue.shift(); //remove first waiting item
+        active++; //track running analyses
+        analyzeError(job.err, job.ctx) //invoke analysis for job
+                .then(job.resolve) //resolve promise with result
+                .catch(job.reject) //propagate errors to caller
+                .finally(() => { active--; processQueue(); }); //schedule next job when done
+}
+
+async function scheduleAnalysis(err, ctx) { //enqueue analyzeError instead of busy wait
+        return new Promise((resolve, reject) => { //wrap queue handling in promise
+                queue.push({ err, ctx, resolve, reject }); //add new job
+                processQueue(); //trigger processing for queue
+        });
 }
 
 function escapeHtml(str) { //escape characters for safe html insertion
@@ -72,15 +91,15 @@ async function analyzeError(error, context) {
 	// Prevent infinite loops by avoiding analysis of network errors from our own API calls
 	// This is critical because axios errors during AI analysis would trigger more analysis
         if (typeof error.name === 'string' && error.name.includes('AxiosError')) { //(skip axios error objects early)
-                console.log(`Axios Error`); //(log axios detection for analysis skip)
+                verboseLog(`Axios Error`); //(log axios detection for analysis skip)
                 return null; //(avoid API call when axios error encountered)
         };
 
         // Log analysis attempt for debugging and tracking purposes
-	// Multi-line format improves readability in console output
-	console.log(`qerrors error analysis is running for
-			error name: "${error.uniqueErrorName}",
-			error message: "${error.message}", 
+        // Multi-line format improves readability in console output
+        verboseLog(`qerrors error analysis is running for
+                        error name: "${error.uniqueErrorName}",
+                        error message: "${error.message}",
                         with context: "${context}"`);
 
         if (!error.qerrorsKey) { //check for existing qerrorsKey on error object
@@ -91,7 +110,7 @@ async function analyzeError(error, context) {
                 const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry
                 adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
                 adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
-                console.log(`cache hit for ${error.uniqueErrorName}`); //log cache usage
+                verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
                 return cached; //skip api call when advice cached
         }
 
@@ -117,43 +136,58 @@ async function analyzeError(error, context) {
 	// OpenAI API call with optimized parameters for error analysis
 	// Model choice balances capability with cost and response time
 	// Parameters tuned for creative but focused debugging suggestions
-  const response = await axiosInstance.post('https://api.openai.com/v1/chat/completions', { //single API request to OpenAI service
-		model: 'gpt-4.1', // Latest model for best analysis quality
-		messages: [{role: 'user',	content: errorPrompt}],
-		response_format: {"type": "json_object"}, // request structured JSON response from API // (changed from text to json_object to match object expectation)
-		temperature: 1, // High creativity for diverse debugging approaches
-                max_tokens: 2048, //changed property name per updated API requirement; still limits advice length
-		top_p: 1, // Full vocabulary access for technical terminology
-		frequency_penalty: 0, // Allow repetition of important debugging concepts
-		presence_penalty: 0 // Don't penalize technical term usage
-	}, {
-		headers: {
-			'Authorization': `Bearer ${process.env.OPENAI_TOKEN}`,
-			'Content-Type': 'application/json'
-		}
-	});
 	
 	// Extract advice with fallback for API response failures
-	// Default message ensures function always returns something useful
-        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture structured advice object returned by OpenAI
+  let response; //will hold axios response
+  for (let i = 0; i <= RETRIES; i++) { //try with retries
+        try {
+                response = await axiosInstance.post('https://api.openai.com/v1/chat/completions', { //single API request to OpenAI service
+                        model: 'gpt-4.1', // Latest model for best analysis quality
+                        messages: [{role: 'user',       content: errorPrompt}],
+                        response_format: {"type": "json_object"}, // request structured JSON response from API // (changed from text to json_object to match object expectation)
+                        temperature: 1, // High creativity for diverse debugging approaches
+                        max_tokens: 2048, //changed property name per updated API requirement; still limits advice length
+                        top_p: 1, // Full vocabulary access for technical terminology
+                        frequency_penalty: 0, // Allow repetition of important debugging concepts
+                        presence_penalty: 0 // Don't penalize technical term usage
+                }, {
+                        headers: {
+                                'Authorization': `Bearer ${process.env.OPENAI_TOKEN}`,
+                                'Content-Type': 'application/json'
+                        }
+                });
+                break; //exit loop on success
+        } catch (apiErr) {
+                if (i === RETRIES) { //give up after retries
+                        verboseLog(`OpenAI request failed after ${RETRIES + 1} attempts`); //log failure
+                        return null; //skip analysis if request never succeeded
+                }
+                await new Promise(r => setTimeout(r, RETRY_DELAY * (2 ** i))); //exponential backoff delay
+        }
+  }
+        // Default message ensures function always returns something useful
+        let advice = response?.data?.choices?.[0]?.message?.content || null; //capture raw advice which may be JSON string
+        if (typeof advice === 'string') { //convert string to object when possible
+                try { advice = JSON.parse(advice); } catch { advice = null; }; //ignore parse errors gracefully
+        }
 	
 	// Validate response structure and handle different API response formats
 	// This defensive programming handles potential API changes or unexpected responses
-	if (advice && typeof advice === 'object') {
-		console.log(`qerrors is returning advice for 
-				the error name: "${error.uniqueErrorName}",
-				with the error message: "${error.message}", 
-				with context: "${context}"`);
+        if (advice && typeof advice === 'object') {
+                verboseLog(`qerrors is returning advice for
+                                the error name: "${error.uniqueErrorName}",
+                                with the error message: "${error.message}",
+                                with context: "${context}"`);
 		
 		// Handle structured response with data property
                 if (advice.data) {
-                        console.log(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
+                        verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
                         adviceCache.set(error.qerrorsKey, advice); //store new advice in cache
                         if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
                         return advice;
                 } else if (advice) {
                         // Handle direct advice object
-                        console.log(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
+                        verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
                         adviceCache.set(error.qerrorsKey, advice); //cache direct advice
                         if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
                         return advice;
@@ -161,7 +195,7 @@ async function analyzeError(error, context) {
 	} else {
 		// Log analysis failure for debugging and monitoring
 		// Provides enough detail to diagnose API issues without exposing sensitive data
-                console.log(`Problem in analyzeError function of qerrors for ${error.uniqueErrorName}: ${error.message}`); // (removed stray quote in log)
+                verboseLog(`Problem in analyzeError function of qerrors for ${error.uniqueErrorName}: ${error.message}`); //log analysis failure
 		return null; // Graceful failure allows application to continue
 	}
 }
@@ -205,9 +239,9 @@ async function qerrors(error, context, req, res, next) {
 	
 	// Log error processing start with full context
 	// Multi-line format improves readability in log aggregation systems
-	console.log(`qerrors is running for error message: "${error.message}", 
-			with context: "${context}", 
-			assigning it the unique error name: "${uniqueErrorName}"`);
+        verboseLog(`qerrors is running for error message: "${error.message}",
+                        with context: "${context}",
+                        assigning it the unique error name: "${uniqueErrorName}"`);
 	
 	// Generate ISO timestamp for consistent log timing across time zones
 	// This is critical for distributed systems and log correlation
@@ -297,7 +331,7 @@ async function qerrors(error, context, req, res, next) {
                 .then(() => scheduleAnalysis(error, context)) //invoke queued analysis after sending response
                 .catch((analysisErr) => logger.error(analysisErr)); //log any scheduleAnalysis failures
 
-        console.log(`qerrors ran`); //log completion after scheduling analysis
+        verboseLog(`qerrors ran`); //log completion after scheduling analysis
 }
 
 // Export main qerrors function as default export


### PR DESCRIPTION
## Summary
- introduce `lib/config.js` that sets default environment variables for qerrors
- queue analyzeError calls instead of busy-waiting and make concurrency configurable
- implement retry logic with backoff for OpenAI requests
- allow cache and log rotation sizes to be configured via environment variables
- support optional verbose console logging
- document all environment variables in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68437229edd48322be2119f5270a01ee