### PR TITLE
Use p-limit for concurrency

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -42,28 +42,10 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 });
 
 
-let active = 0; //count of active analyses to limit concurrency
+const limit = pLimit(Number(process.env.QERRORS_CONCURRENCY) || 5); //create limiter with env based concurrency
 
-const limit = parseInt(process.env.QERRORS_CONCURRENCY, 10) || 5; //set concurrency from env var or default to 5
-
-const queue = pLimit(limit); //queue with concurrency limit
-
-function processQueue() { //start next queued analysis if capacity
-        if (active >= limit || queue.length === 0) return; //exit if busy or none queued
-        const job = queue.shift(); //remove first waiting item
-        active++; //track running analyses
-        analyzeError(job.err, job.ctx) //invoke analysis for job
-                .then(job.resolve) //resolve promise with result
-                .catch(job.reject) //propagate errors to caller
-                .finally(() => { active--; processQueue(); }); //schedule next job when done
-}
-
-async function scheduleAnalysis(err, ctx) { //enqueue analyzeError instead of busy wait
-        return new Promise((resolve, reject) => { //wrap queue handling in promise
-                queue.push({ err, ctx, resolve, reject }); //add new job
-                processQueue(); //trigger processing for queue
-        });
-
+async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
+        return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 }
 
 function escapeHtml(str) { //escape characters for safe html insertion


### PR DESCRIPTION
## Summary
- remove custom job queue logic
- add p-limit limiter based on `QERRORS_CONCURRENCY`
- schedule analysis through limiter

## Testing
- `npm test` *(fails: SyntaxError: Identifier 'rotationOpts' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_b_68437a9e49cc832287b0217aaf3aa62c