### PR TITLE
Fix logger syntax error

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -17,9 +17,8 @@
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
 
 require('./config'); //ensure environment defaults are loaded
-const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //log rotation from env
+const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //log rotation from env; removed duplicate definition
 
-const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 
 
 /**

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -42,28 +42,12 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 });
 
 
-let active = 0; //count of active analyses to limit concurrency
-
 const limit = parseInt(process.env.QERRORS_CONCURRENCY, 10) || 5; //set concurrency from env var or default to 5
 
-const queue = pLimit(limit); //queue with concurrency limit
+const queue = pLimit(limit); //queue function for concurrency limit
 
-function processQueue() { //start next queued analysis if capacity
-        if (active >= limit || queue.length === 0) return; //exit if busy or none queued
-        const job = queue.shift(); //remove first waiting item
-        active++; //track running analyses
-        analyzeError(job.err, job.ctx) //invoke analysis for job
-                .then(job.resolve) //resolve promise with result
-                .catch(job.reject) //propagate errors to caller
-                .finally(() => { active--; processQueue(); }); //schedule next job when done
-}
-
-async function scheduleAnalysis(err, ctx) { //enqueue analyzeError instead of busy wait
-        return new Promise((resolve, reject) => { //wrap queue handling in promise
-                queue.push({ err, ctx, resolve, reject }); //add new job
-                processQueue(); //trigger processing for queue
-        });
-
+function scheduleAnalysis(err, ctx) { //queue analyzeError using p-limit
+        return queue(() => analyzeError(err, ctx)); //return queued promise for analysis
 }
 
 function escapeHtml(str) { //escape characters for safe html insertion


### PR DESCRIPTION
## Summary
- clean up logger configuration by removing duplicate `rotationOpts`
- simplify qerrors async queue to use `p-limit` directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68437aaaec688322aa0bf46681dc35d7