### PR TITLE
Remove old scheduler implementation

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -42,29 +42,7 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 
 
 
-let active = 0; //count of active analyses to limit concurrency
-
 const limit = pLimit(Number(process.env.QERRORS_CONCURRENCY, 10) || 5); //create limiter with env based concurrency
-
-const queue = []; //pending analyses waiting for free slot
-
-
-function processQueue() { //start next queued analysis if capacity
-        if (active >= limit || queue.length === 0) return; //exit if busy or none queued
-        const job = queue.shift(); //remove first waiting item
-        active++; //track running analyses
-        analyzeError(job.err, job.ctx) //invoke analysis for job
-                .then(job.resolve) //resolve promise with result
-                .catch(job.reject) //propagate errors to caller
-                .finally(() => { active--; processQueue(); }); //schedule next job when done
-}
-
-async function scheduleAnalysis(err, ctx) { //enqueue analyzeError instead of busy wait
-        return new Promise((resolve, reject) => { //wrap queue handling in promise
-                queue.push({ err, ctx, resolve, reject }); //add new job
-                processQueue(); //trigger processing for queue
-        });
-
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise


### PR DESCRIPTION
## Summary
- delete unused queue-based scheduling code from `lib/qerrors.js`
- keep p-limit version of `scheduleAnalysis`

## Testing
- `npm test` *(fails: ReferenceError: test is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68438682d9cc83229f1abc39d219579f