### PR TITLE
Replace qerrors call in envUtils

### DIFF
--- a/lib/envUtils.js
+++ b/lib/envUtils.js
@@ -42,8 +42,7 @@ function throwIfMissingEnvVars(varArr) {
                const errorMessage = `Missing required environment variables: ${missingEnvVars.join(', ')}`; //(construct error)
                console.error(errorMessage); //log prior to throw
                const err = new Error(errorMessage); //create error object
-               const qerrors = require('./qerrors'); //import qerrors
-               qerrors(err, 'throwIfMissingEnvVars error', { varArr }); //report via qerrors
+               console.error(err); //log error instead of calling qerrors to avoid recursion
                throw err; //propagate failure
        }
 


### PR DESCRIPTION
## Summary
- swap qerrors call for a simple `console.error` in `throwIfMissingEnvVars`

## Testing
- `npm test` *(fails: SyntaxError in lib/qerrors.js)*

------
https://chatgpt.com/codex/tasks/task_b_684386979d648322bebe6193f843cde0