### PR TITLE
Fix retry env names docs and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`).
 * `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`).
 
-* `QERRORS_RETRIES` &ndash; attempts when calling OpenAI (default `3`).
-* `QERRORS_RETRY_DELAY_MS` &ndash; base delay in ms for retries (default `500`).
+* `QERRORS_RETRY_ATTEMPTS` &ndash; attempts when calling OpenAI (default `2`).
+* `QERRORS_RETRY_BASE_MS` &ndash; base delay in ms for retries (default `100`).
 * `QERRORS_TIMEOUT` &ndash; axios request timeout in ms (default `10000`).
 
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,8 +4,8 @@ const defaults = { //default environment variable values
   QERRORS_CONCURRENCY: '5', //max concurrent analyses
   QERRORS_CACHE_LIMIT: '50', //LRU cache size
 
-  QERRORS_RETRIES: '3', //number of API retries
-  QERRORS_RETRY_DELAY_MS: '500', //base delay for retries
+  QERRORS_RETRY_ATTEMPTS: '2', //number of API retries //(renamed env var and updated default)
+  QERRORS_RETRY_BASE_MS: '100', //base delay for retries //(renamed env var and updated default)
   QERRORS_TIMEOUT: '10000', //axios request timeout in ms
 
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
@@ -20,3 +20,9 @@ for (const key in defaults) { //iterate through defaults
 }
 
 module.exports = defaults; //export defaults for external use
+
+function safeRun(name, fn, fallback, info) { //utility wrapper for try/catch //(added helper)
+  try { return fn(); } catch (err) { console.error(`${name} failed`, info); return fallback; } //(log and fall back)
+}
+
+module.exports.safeRun = safeRun; //export safeRun for env utils //(make accessible)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -86,6 +86,11 @@ const logger = createLogger({
 	]
 });
 
+function logStart(name, data) { logger.info(`${name} start ${JSON.stringify(data)}`); } //log start info //(use info to match stub)
+function logReturn(name, data) { logger.info(`${name} return ${JSON.stringify(data)}`); } //log result info //(use info to match stub)
+
 // Export configured logger instance
 // This provides a consistent logging interface across the entire qerrors module
 module.exports = logger;
+module.exports.logStart = logStart; //export start logger //(make available to env utils)
+module.exports.logReturn = logReturn; //export return logger //(make available to env utils)

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -64,7 +64,7 @@ async function scheduleAnalysis(err, ctx) { //enqueue analyzeError instead of bu
                 queue.push({ err, ctx, resolve, reject }); //add new job
                 processQueue(); //trigger processing for queue
         });
-
+} //(close first scheduleAnalysis)
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise

--- a/test/envUtils.test.js
+++ b/test/envUtils.test.js
@@ -1,4 +1,5 @@
 
+const test = require('node:test'); //node test runner //(import node test)
 const assert = require('assert');
 const qtests = require('qtests');
 const { getMissingEnvVars, throwIfMissingEnvVars, warnIfMissingEnvVars } = require('../lib/envUtils');


### PR DESCRIPTION
## Summary
- update README with `QERRORS_RETRY_ATTEMPTS` and `QERRORS_RETRY_BASE_MS`
- switch config defaults to new retry env names
- restore missing brace in qerrors
- add safeRun helper and stub logger helpers
- fix envUtils tests to use node:test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684386fbf2dc83229295b75c1caa3257