### PR TITLE
Add QERRORS_MAX_SOCKETS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_RETRY_ATTEMPTS` &ndash; attempts when calling OpenAI (default `2`).
 * `QERRORS_RETRY_BASE_MS` &ndash; base delay in ms for retries (default `100`).
 * `QERRORS_TIMEOUT` &ndash; axios request timeout in ms (default `10000`).
+* `QERRORS_MAX_SOCKETS` &ndash; maximum sockets per agent (default `50`).
 
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
@@ -25,6 +26,8 @@ qerrors reads several environment variables to tune its behavior. A small config
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com). //env variable for OpenAI access
 Set QERRORS_CONCURRENCY to adjust how many analyses run simultaneously; //new variable controlling concurrency
 if not set the default limit is 5. //explain fallback value
+QERRORS_MAX_SOCKETS lets you limit how many sockets the http agents open; //document new env var usage
+if not set the default is 50. //state default behaviour
 
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com). //(mention required token)

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ const defaults = { //default environment variable values
   QERRORS_RETRY_ATTEMPTS: '2', //number of API retries //(renamed env var and updated default)
   QERRORS_RETRY_BASE_MS: '100', //base delay for retries //(renamed env var and updated default)
   QERRORS_TIMEOUT: '10000', //axios request timeout in ms
+  QERRORS_MAX_SOCKETS: '50', //max sockets per http/https agent
 
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -35,8 +35,8 @@ const ADVICE_CACHE_LIMIT = Number(process.env.QERRORS_CACHE_LIMIT) || 50; //max 
 const adviceCache = new Map(); //Map used for LRU cache implementation
 
 const axiosInstance = axios.create({ //axios instance with keep alive agents
-        httpAgent: new http.Agent({ keepAlive: true }), //reuse http connections
-        httpsAgent: new https.Agent({ keepAlive: true }), //reuse https connections
+        httpAgent: new http.Agent({ keepAlive: true, maxSockets: Number(process.env.QERRORS_MAX_SOCKETS) }), //reuse http connections with limit
+        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: Number(process.env.QERRORS_MAX_SOCKETS) }), //reuse https connections with limit
         timeout: Number(process.env.QERRORS_TIMEOUT) || 10000 //abort request after timeout
 });
 

--- a/test/maxSockets.test.js
+++ b/test/maxSockets.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //strict assertions
+
+function reloadQerrors() { //reload qerrors with current env
+  delete require.cache[require.resolve('../lib/qerrors')]; //remove cached qerrors
+  delete require.cache[require.resolve('../lib/config')]; //remove cached config to apply defaults
+  return require('../lib/qerrors'); //return fresh module
+}
+
+test('axiosInstance honors QERRORS_MAX_SOCKETS', () => {
+  const orig = process.env.QERRORS_MAX_SOCKETS; //save original value
+  process.env.QERRORS_MAX_SOCKETS = '10'; //set custom sockets
+  const { axiosInstance } = reloadQerrors(); //reload with env variable
+  try {
+    assert.equal(axiosInstance.defaults.httpAgent.maxSockets, 10); //http agent uses env
+    assert.equal(axiosInstance.defaults.httpsAgent.maxSockets, 10); //https agent uses env
+  } finally {
+    if (orig === undefined) { delete process.env.QERRORS_MAX_SOCKETS; } else { process.env.QERRORS_MAX_SOCKETS = orig; }
+    reloadQerrors(); //restore module state
+  }
+});
+
+test('axiosInstance uses default max sockets when env missing', () => {
+  const orig = process.env.QERRORS_MAX_SOCKETS; //capture original env
+  delete process.env.QERRORS_MAX_SOCKETS; //unset for default test
+  const { axiosInstance } = reloadQerrors(); //reload with defaults
+  try {
+    assert.equal(axiosInstance.defaults.httpAgent.maxSockets, 50); //default http agent value
+    assert.equal(axiosInstance.defaults.httpsAgent.maxSockets, 50); //default https agent value
+  } finally {
+    if (orig === undefined) { delete process.env.QERRORS_MAX_SOCKETS; } else { process.env.QERRORS_MAX_SOCKETS = orig; }
+    reloadQerrors(); //reset module state
+  }
+});


### PR DESCRIPTION
## Summary
- add `QERRORS_MAX_SOCKETS` default in config
- use the new value when creating HTTP/HTTPS agents
- document the variable in README
- test new socket limit behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684394de707c83229a30f96078b6612f