### PR TITLE
Remove obsolete queue logic from scheduleAnalysis

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -45,26 +45,6 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 const limit = pLimit(Number(process.env.QERRORS_CONCURRENCY, 10) || 5); //create limiter with env based concurrency
 
 
-const queue = []; //pending analyses waiting for free slot
-
-
-function processQueue() { //start next queued analysis if capacity
-        if (active >= limit || queue.length === 0) return; //exit if busy or none queued
-        const job = queue.shift(); //remove first waiting item
-        active++; //track running analyses
-        analyzeError(job.err, job.ctx) //invoke analysis for job
-                .then(job.resolve) //resolve promise with result
-                .catch(job.reject) //propagate errors to caller
-                .finally(() => { active--; processQueue(); }); //schedule next job when done
-}
-
-async function scheduleAnalysis(err, ctx) { //enqueue analyzeError instead of busy wait
-        return new Promise((resolve, reject) => { //wrap queue handling in promise
-                queue.push({ err, ctx, resolve, reject }); //add new job
-                processQueue(); //trigger processing for queue
-        });
-
-} //(close first scheduleAnalysis)
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise


### PR DESCRIPTION
## Summary
- strip unused queue and processQueue logic
- keep p-limit implementation of `scheduleAnalysis`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684394ee6318832282f8d6c2f0b5da74