### PR TITLE
Allow disabling advice cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 
 * `OPENAI_TOKEN` &ndash; your OpenAI API key.
 * `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`).
-* `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`).
+* `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching).
 
 * `QERRORS_RETRY_ATTEMPTS` &ndash; attempts when calling OpenAI (default `2`).
 * `QERRORS_RETRY_BASE_MS` &ndash; base delay in ms for retries (default `100`).
@@ -31,7 +31,7 @@ You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](
 The retry behaviour can be tuned with QERRORS_RETRY_ATTEMPTS and QERRORS_RETRY_BASE_MS which default to 2 and 100 respectively. //(document retry env vars)
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
-You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; the default is 50.
+You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50).
 
 Additional options control the logger's file rotation:
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -30,7 +30,8 @@ function verboseLog(msg) { //conditional console output helper
 }
 
 
-const ADVICE_CACHE_LIMIT = Number(process.env.QERRORS_CACHE_LIMIT) || 50; //max cache entries configurable by env
+const parsedLimit = parseInt(process.env.QERRORS_CACHE_LIMIT, 10); //parse limit from env for caching
+const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : (parsedLimit || 50); //0 disables cache otherwise default to 50
 
 const adviceCache = new Map(); //Map used for LRU cache implementation
 
@@ -128,12 +129,12 @@ async function analyzeError(error, context) {
                 error.qerrorsKey = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //hash message and stack for caching
         }
 
-        if (adviceCache.has(error.qerrorsKey)) { //return cached advice when available
+        if (ADVICE_CACHE_LIMIT !== 0 && adviceCache.has(error.qerrorsKey)) { //skip api call when caching enabled and hit
                 const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry
                 adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
                 adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
                 verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
-                return cached; //skip api call when advice cached
+                return cached; //return cached advice
         }
 
         // Graceful degradation when API token is not available
@@ -201,14 +202,18 @@ async function analyzeError(error, context) {
 		// Handle structured response with data property
                 if (advice.data) {
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
-                        adviceCache.set(error.qerrorsKey, advice); //store new advice in cache
-                        if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
+                        if (ADVICE_CACHE_LIMIT !== 0) { //only cache when limit not zero
+                                adviceCache.set(error.qerrorsKey, advice); //store new advice in cache
+                                if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
+                        }
                         return advice;
                 } else if (advice) {
                         // Handle direct advice object
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
-                        adviceCache.set(error.qerrorsKey, advice); //cache direct advice
-                        if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
+                        if (ADVICE_CACHE_LIMIT !== 0) { //cache only if enabled
+                                adviceCache.set(error.qerrorsKey, advice); //cache direct advice
+                                if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
+                        }
                         return advice;
                 }
 	} else {


### PR DESCRIPTION
## Summary
- parse `QERRORS_CACHE_LIMIT` with `parseInt`
- allow cache limit `0` to disable caching
- document new env var behaviour
- test disabling the cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684395130ea883228d0e4d640012a0d3