### PR TITLE
Add logging env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
 * `QERRORS_VERBOSE` &ndash; enable console logging (`true` by default).
+* `QERRORS_LOG_DIR` &ndash; directory for logger output (default `logs`).
+* `QERRORS_DISABLE_FILE_LOGS` &ndash; disable file transports when set.
 
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com). //env variable for OpenAI access
@@ -37,6 +39,8 @@ Additional options control the logger's file rotation:
 
 * `QERRORS_LOG_MAXSIZE` - max log file size in bytes before rotation (default `1048576`)
 * `QERRORS_LOG_MAXFILES` - number of rotated files to keep (default `5`)
+* `QERRORS_LOG_DIR` - path for log files (default `logs`)
+* `QERRORS_DISABLE_FILE_LOGS` - omit file logs when set
 
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,7 +10,9 @@ const defaults = { //default environment variable values
 
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files
-  QERRORS_VERBOSE: 'true' //enable verbose console logs
+  QERRORS_VERBOSE: 'true', //enable verbose console logs
+  QERRORS_LOG_DIR: 'logs', //directory for rotated logs
+  QERRORS_DISABLE_FILE_LOGS: '' //flag to disable file transports when set
 };
 
 for (const key in defaults) { //iterate through defaults

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,9 +15,11 @@
  */
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
+const path = require('path'); //path for building log file paths
 
 require('./config'); //ensure environment defaults are loaded
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
+const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 
 
 /**
@@ -70,20 +72,16 @@ const logger = createLogger({
 	// Service identification helps in multi-service environments
 	defaultMeta: { service: 'user-service' },
 	
-	// Multi-transport configuration for comprehensive log coverage
-	transports: [
-		// Error-only file transport for focused error analysis and monitoring
-		// Separate file makes error tracking and alerting more efficient
-               new transports.File({ filename: 'error.log', level: 'error', ...rotationOpts }), //(rotate error log when size limit hit)
-		
-		// Combined log file for comprehensive audit trail
-		// Includes all log levels for complete application behavior tracking
-               new transports.File({ filename: 'combined.log', ...rotationOpts }), //(rotate combined log using same options)
-		
-		// Console transport for immediate feedback during development
-		// Also useful for containerized deployments where logs go to stdout
-		new transports.Console()
-	]
+        // Multi-transport configuration for comprehensive log coverage
+        transports: (() => {
+                const arr = []; //start with no transports
+                if (!process.env.QERRORS_DISABLE_FILE_LOGS) { //add files when not disabled
+                        arr.push(new transports.File({ filename: path.join(logDir, 'error.log'), level: 'error', ...rotationOpts }));
+                        arr.push(new transports.File({ filename: path.join(logDir, 'combined.log'), ...rotationOpts }));
+                }
+                if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //console only when verbose
+                return arr; //provide configured transports
+        })()
 });
 
 function logStart(name, data) { logger.info(`${name} start ${JSON.stringify(data)}`); } //log start info //(use info to match stub)


### PR DESCRIPTION
## Summary
- add log control vars to config
- respect new env vars in logger
- document logging variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684395281f548322b222121e90bf3e21