### PR TITLE
Add service name config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_VERBOSE` &ndash; enable console logging (`true` by default).
 * `QERRORS_LOG_DIR` &ndash; directory for logger output (default `logs`).
 * `QERRORS_DISABLE_FILE_LOGS` &ndash; disable file transports when set.
+* `QERRORS_SERVICE_NAME` &ndash; service name added to logger metadata (default `qerrors`). //(document service variable)
 
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com). //env variable for OpenAI access
@@ -52,6 +53,7 @@ Additional options control the logger's file rotation:
 * `QERRORS_LOG_MAXFILES` - number of rotated files to keep (default `5`)
 * `QERRORS_LOG_DIR` - path for log files (default `logs`)
 * `QERRORS_DISABLE_FILE_LOGS` - omit file logs when set
+* `QERRORS_SERVICE_NAME` - service name added to logger metadata (default `qerrors`)
 
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,8 @@ const defaults = { //default environment variable values
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files
   QERRORS_VERBOSE: 'true', //enable verbose console logs
   QERRORS_LOG_DIR: 'logs', //directory for rotated logs
-  QERRORS_DISABLE_FILE_LOGS: '' //flag to disable file transports when set
+  QERRORS_DISABLE_FILE_LOGS: '', //flag to disable file transports when set
+  QERRORS_SERVICE_NAME: 'qerrors' //service identifier for logger //(new default)
 };
 
 for (const key in defaults) { //iterate through defaults

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -68,9 +68,9 @@ const logger = createLogger({
 		})
 	),
 	
-	// Default metadata added to all log entries
-	// Service identification helps in multi-service environments
-	defaultMeta: { service: 'user-service' },
+        // Default metadata added to all log entries
+        // Service identification helps in multi-service environments
+        defaultMeta: { service: process.env.QERRORS_SERVICE_NAME }, //(use env service name)
 	
         // Multi-transport configuration for comprehensive log coverage
         transports: (() => {

--- a/test/serviceName.test.js
+++ b/test/serviceName.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing helper
+const winston = require('winston'); //stubbed winston module
+
+function reloadLogger() { //reload logger with current env
+  delete require.cache[require.resolve('../lib/logger')];
+  delete require.cache[require.resolve('../lib/config')];
+  return require('../lib/logger');
+}
+
+test('logger uses QERRORS_SERVICE_NAME env var', () => {
+  const orig = process.env.QERRORS_SERVICE_NAME; //save original value
+  process.env.QERRORS_SERVICE_NAME = 'svc'; //set custom name
+  let captured; //will capture config passed to createLogger
+  const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta }; });
+  const logger = reloadLogger(); //reload module
+  try {
+    assert.equal(captured.defaultMeta.service, 'svc'); //verify custom service
+    assert.equal(logger.defaultMeta.service, 'svc'); //logger carries meta
+  } finally {
+    restore(); //restore stubbed method
+    if (orig === undefined) { delete process.env.QERRORS_SERVICE_NAME; } else { process.env.QERRORS_SERVICE_NAME = orig; }
+    reloadLogger(); //reset cache
+  }
+});
+
+test('logger defaults QERRORS_SERVICE_NAME when unset', () => {
+  const orig = process.env.QERRORS_SERVICE_NAME; //store original
+  delete process.env.QERRORS_SERVICE_NAME; //unset for default test
+  let captured; //capture config
+  const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta }; });
+  const logger = reloadLogger(); //reload module
+  try {
+    assert.equal(captured.defaultMeta.service, 'qerrors'); //uses default
+    assert.equal(logger.defaultMeta.service, 'qerrors'); //logger meta default
+  } finally {
+    restore(); //restore stub
+    if (orig === undefined) { delete process.env.QERRORS_SERVICE_NAME; } else { process.env.QERRORS_SERVICE_NAME = orig; }
+    reloadLogger(); //restore cache
+  }
+});


### PR DESCRIPTION
## Summary
- add `QERRORS_SERVICE_NAME` default
- read `QERRORS_SERVICE_NAME` in logger
- document service name in README
- test logger service name behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68439fea8714832289e15af4fbfd2a7d