### PR TITLE
Refactor config defaults

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,13 +18,15 @@ const defaults = { //default environment variable values
   QERRORS_SERVICE_NAME: 'qerrors' //service identifier for logger //(new default)
 };
 
-for (const key in defaults) { //iterate through defaults
-  if (!process.env[key]) { //assign when variable undefined
-    process.env[key] = defaults[key]; //set environment variable to default
-  }
-}
+
 
 module.exports = defaults; //export defaults for external use
+
+function getEnv(name) { //return env var or default when undefined
+  return process.env[name] !== undefined ? process.env[name] : defaults[name];
+}
+
+module.exports.getEnv = getEnv; //expose getEnv helper
 
 function safeRun(name, fn, fallback, info) { //utility wrapper for try/catch //(added helper)
   try { return fn(); } catch (err) { console.error(`${name} failed`, info); return fallback; } //(log and fall back)
@@ -33,7 +35,7 @@ function safeRun(name, fn, fallback, info) { //utility wrapper for try/catch //(
 module.exports.safeRun = safeRun; //export safeRun for env utils //(make accessible)
 
 function getInt(name) { //parse env integer with fallback
-  const int = parseInt(process.env[name], 10); //attempt parse
+  const int = parseInt(getEnv(name), 10); //attempt parse
   return Number.isNaN(int) ? parseInt(defaults[name], 10) : int; //default when NaN
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -16,10 +16,10 @@
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
 const path = require('path'); //path for building log file paths
+const config = require('./config'); //load config helpers for defaults
 
-require('./config'); //ensure environment defaults are loaded
-const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
-const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
+const rotationOpts = { maxsize: config.getInt('QERRORS_LOG_MAXSIZE'), maxFiles: config.getInt('QERRORS_LOG_MAXFILES'), tailable: true }; //(use env config when rotating logs)
+const logDir = config.getEnv('QERRORS_LOG_DIR'); //directory to store log files
 
 
 /**
@@ -70,16 +70,16 @@ const logger = createLogger({
 	
         // Default metadata added to all log entries
         // Service identification helps in multi-service environments
-        defaultMeta: { service: process.env.QERRORS_SERVICE_NAME }, //(use env service name)
+        defaultMeta: { service: config.getEnv('QERRORS_SERVICE_NAME') }, //(use env service name)
 	
         // Multi-transport configuration for comprehensive log coverage
         transports: (() => {
                 const arr = []; //start with no transports
-                if (!process.env.QERRORS_DISABLE_FILE_LOGS) { //add files when not disabled
+                if (!config.getEnv('QERRORS_DISABLE_FILE_LOGS')) { //add files when not disabled
                         arr.push(new transports.File({ filename: path.join(logDir, 'error.log'), level: 'error', ...rotationOpts }));
                         arr.push(new transports.File({ filename: path.join(logDir, 'combined.log'), ...rotationOpts }));
                 }
-                if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //console only when verbose
+                if (config.getEnv('QERRORS_VERBOSE') === 'true') { arr.push(new transports.Console()); } //console only when verbose
                 return arr; //provide configured transports
         })()
 });

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -26,12 +26,12 @@ const pLimit = require('p-limit'); //lightweight promise queue for concurrency c
 
 
 function verboseLog(msg) { //conditional console output helper
-        if (process.env.QERRORS_VERBOSE === 'true') console.log(msg); //only log when enabled
+        if (config.getEnv('QERRORS_VERBOSE') === 'true') console.log(msg); //only log when enabled
 }
 
 
-const parsedLimit = parseInt(process.env.QERRORS_CACHE_LIMIT, 10); //parse limit from env for caching
-const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : (parsedLimit || 50); //0 disables cache otherwise default to 50
+const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT'); //parse limit from env or defaults
+const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit
 
 const adviceCache = new Map(); //Map used for LRU cache implementation
 


### PR DESCRIPTION
## Summary
- stop setting defaults on `process.env`
- add `getEnv` helper and update `getInt`
- use config helpers in logger
- read cache limit and verbosity from config in qerrors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843bcb82108832285c51f1f454ef858