### PR TITLE
Fix logger config usage

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -16,10 +16,8 @@
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
 const path = require('path'); //path for building log file paths
-
+const config = require('./config'); //load configuration for env defaults
 const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rotation transport //(enable time based rotation)
-
-require('./config'); //ensure environment defaults are loaded
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files


### PR DESCRIPTION
## Summary
- import `config` in logger to access environment helpers
- ensure logger metadata uses `config` module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843cbc251e88322a6faa10cf9d53169