### PR TITLE
Implement one-time OPENAI_TOKEN warning

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -35,6 +35,8 @@ const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cac
 
 const adviceCache = new Map(); //Map used for LRU cache implementation
 
+let warnedMissingToken = false; //track if missing token message already logged
+
 const axiosInstance = axios.create({ //axios instance with keep alive agents
         httpAgent: new http.Agent({ keepAlive: true, maxSockets: config.getInt('QERRORS_MAX_SOCKETS') }), //reuse http connections with limit
         httpsAgent: new https.Agent({ keepAlive: true, maxSockets: config.getInt('QERRORS_MAX_SOCKETS') }), //reuse https connections with limit
@@ -125,11 +127,14 @@ async function analyzeError(error, context) {
         }
 
         // Graceful degradation when API token is not available
-        // Returns null rather than throwing to maintain application stability
+        // Only log once to avoid repeated console noise on subsequent calls
         if (!process.env.OPENAI_TOKEN) {
-                console.error("Missing OPENAI_TOKEN in environment variables.");
-                return null;
-	}
+                if (!warnedMissingToken) { //check if warning already logged
+                        console.error(`Missing OPENAI_TOKEN in environment variables.`); //inform developer about missing token
+                        warnedMissingToken = true; //set flag so we do not warn again
+                }
+                return null; //skip analysis when token absent
+        }
 	
         // Carefully crafted prompt that optimizes for practical debugging advice
         // Specific instructions prevent unhelpful generic responses and formatting issues


### PR DESCRIPTION
## Summary
- add `warnedMissingToken` flag
- only warn once when OPENAI_TOKEN is missing

## Testing
- `npm test` *(fails: "config is not defined" in logger.js)*

------
https://chatgpt.com/codex/tasks/task_b_6843cbcc43788322bdaea9cc193adde9