### PR TITLE
Add verbose logger test

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -19,7 +19,7 @@ const path = require('path'); //path for building log file paths
 
 const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rotation transport //(enable time based rotation)
 
-require('./config'); //ensure environment defaults are loaded
+const config = require('./config'); //ensure environment defaults are loaded and provide helper access
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files

--- a/test/verbose.test.js
+++ b/test/verbose.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+const winston = require('winston'); //winston stub
+
+function reloadLogger() { //reload logger for each test
+  delete require.cache[require.resolve('../lib/logger')];
+  delete require.cache[require.resolve('../lib/config')];
+  return require('../lib/logger');
+}
+
+test('logger adds Console transport when verbose true', () => {
+  const orig = process.env.QERRORS_VERBOSE; //save original env
+  process.env.QERRORS_VERBOSE = 'true'; //enable console logging
+  let captured; //will hold config passed in
+  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports }; }); //capture transports
+  const logger = reloadLogger(); //load module under new env
+  try {
+    const hasConsole = captured.transports.some(t => t instanceof winston.transports.Console); //check captured transports
+    assert.equal(hasConsole, true); //expect console present
+    assert.equal(logger.transports.length, captured.transports.length); //logger returns same transports
+  } finally {
+    restore(); //restore stub
+    if (orig === undefined) { delete process.env.QERRORS_VERBOSE; } else { process.env.QERRORS_VERBOSE = orig; } //restore env
+    reloadLogger(); //clear cache
+  }
+});
+
+test('logger excludes Console transport when verbose false', () => {
+  const orig = process.env.QERRORS_VERBOSE; //save env
+  process.env.QERRORS_VERBOSE = 'false'; //disable console
+  let captured; //hold config
+  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports }; }); //capture transports
+  const logger = reloadLogger(); //reload module
+  try {
+    const hasConsole = captured.transports.some(t => t instanceof winston.transports.Console); //detect console
+    assert.equal(hasConsole, false); //expect none
+    assert.equal(logger.transports.length, captured.transports.length); //verify exports
+  } finally {
+    restore(); //cleanup stub
+    if (orig === undefined) { delete process.env.QERRORS_VERBOSE; } else { process.env.QERRORS_VERBOSE = orig; } //restore env
+    reloadLogger(); //reset
+  }
+});


### PR DESCRIPTION
## Summary
- load config properly in logger.js
- add verbose.test.js to check Console transport behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843cbd786648322b064999d8433eec0