### PR TITLE
Enforce integer minimums

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -35,9 +35,10 @@ function safeRun(name, fn, fallback, info) { //utility wrapper for try/catch //(
 
 module.exports.safeRun = safeRun; //export safeRun for env utils //(make accessible)
 
-function getInt(name) { //parse env integer with fallback
+function getInt(name, min = 1) { //parse env integer with minimum enforcement
   const int = parseInt(getEnv(name), 10); //attempt parse
-  return Number.isNaN(int) ? parseInt(defaults[name], 10) : int; //default when NaN
+  const val = Number.isNaN(int) ? parseInt(defaults[name], 10) : int; //default when NaN
+  return val >= min ? val : min; //enforce allowed minimum
 }
 
 module.exports.getInt = getInt; //export helper for qerrors usage //(central helper)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -19,9 +19,6 @@ const path = require('path'); //path for building log file paths
 const config = require('./config'); //load configuration for env defaults
 const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rotation transport //(enable time based rotation)
 
-
-const config = require('./config'); //ensure environment defaults are loaded and provide helper access
-
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -30,7 +30,7 @@ function verboseLog(msg) { //conditional console output helper
 }
 
 
-const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT'); //parse limit from env or defaults
+const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit
 
 const adviceCache = new Map(); //Map used for LRU cache implementation


### PR DESCRIPTION
## Summary
- add minimum enforcement to `getInt`
- allow cache limit to be zero
- adjust queue limit tests for new behavior
- clean duplicate require from logger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843d27c7d2c83228be8ed352e59c17f