### PR TITLE
Fix logger env parsing

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -19,11 +19,8 @@ const path = require('path'); //path for building log file paths
 const config = require('./config'); //load configuration for env defaults
 const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rotation transport //(enable time based rotation)
 
-
-const config = require('./config'); //ensure environment defaults are loaded and provide helper access
-
-const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
-const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
+const rotationOpts = { maxsize: config.getInt('QERRORS_LOG_MAXSIZE'), maxFiles: config.getInt('QERRORS_LOG_MAXFILES'), tailable: true }; //refactor to use config.getInt for numeric env vars
+const maxDays = config.getInt('QERRORS_LOG_MAX_DAYS'); //use helper to honor 0 value
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 
 


### PR DESCRIPTION
## Summary
- fix duplicated config require in logger
- parse logger size, file count, and retention with `config.getInt`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843d2e4dc588322a4929165bba7b3fd