### PR TITLE
Store concurrency env vars once

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -19,9 +19,6 @@ const path = require('path'); //path for building log file paths
 const config = require('./config'); //load configuration for env defaults
 const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rotation transport //(enable time based rotation)
 
-
-const config = require('./config'); //ensure environment defaults are loaded and provide helper access
-
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -29,6 +29,9 @@ function verboseLog(msg) { //conditional console output helper
         if (config.getEnv('QERRORS_VERBOSE') === 'true') console.log(msg); //only log when enabled
 }
 
+const CONCURRENCY_LIMIT = config.getInt('QERRORS_CONCURRENCY'); //store concurrency at module load
+const QUEUE_LIMIT = config.getInt('QERRORS_QUEUE_LIMIT'); //store queue limit at module load
+
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT'); //parse limit from env or defaults
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit
@@ -45,15 +48,14 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 
 
 
-const limit = pLimit(config.getInt('QERRORS_CONCURRENCY')); //create limiter with env based concurrency
+const limit = pLimit(CONCURRENCY_LIMIT); //create limiter with stored concurrency
 
 let queueRejectCount = 0; //track how many analyses the queue rejects
 
 
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
-        const conc = config.getInt('QERRORS_CONCURRENCY'); //read concurrency limit
-        if (limit.pendingCount >= config.getInt('QERRORS_QUEUE_LIMIT') && limit.activeCount >= conc) { queueRejectCount++; logger.warn('analysis queue full'); return Promise.reject(new Error('queue full')); } //(reject when queue and active exceed limits)
+        if (limit.pendingCount >= QUEUE_LIMIT && limit.activeCount >= CONCURRENCY_LIMIT) { queueRejectCount++; logger.warn('analysis queue full'); return Promise.reject(new Error('queue full')); } //(reject when queue and active exceed limits)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 
 }


### PR DESCRIPTION
## Summary
- store QERRORS_CONCURRENCY and QERRORS_QUEUE_LIMIT when the module loads
- use stored values when creating the limiter
- remove duplicate config import in logger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843d2fe913883228e2a5f359454291a