### PR TITLE
Fix logger initialization directory creation

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -16,12 +16,14 @@
 
 const { createLogger, format, transports } = require('winston'); //import winston logging primitives
 const path = require('path'); //path for building log file paths
+const fs = require('fs'); //filesystem for logDir creation
 const config = require('./config'); //load configuration for env defaults
 const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rotation transport //(enable time based rotation)
 
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
+fs.mkdirSync(logDir, { recursive: true }); //create logDir before using transports
 
 
 


### PR DESCRIPTION
## Summary
- ensure logging directory is created before transports are set up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843dc2669a4832294491e3734292add