### PR TITLE
Add clearAdviceCache utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ if not set the default limit is 100; increase when expecting heavy load. //(expl
 
 Whenever the queue rejects an analysis the module increments an internal counter. //(document reject counter)
 Check it with `qerrors.getQueueRejectCount()`. //(usage note)
+Call `qerrors.clearAdviceCache()` to manually empty the advice cache. //(document cache clearing)
 
 QERRORS_MAX_SOCKETS lets you limit how many sockets the http agents open; //document new env var usage
 if not set the default is 50; raise this to handle high traffic. //state default behaviour

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -62,6 +62,8 @@ async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
 
 function getQueueRejectCount() { return queueRejectCount; } //expose reject count
 
+function clearAdviceCache() { adviceCache.clear(); } //empty the advice cache map
+
 function escapeHtml(str) { //escape characters for safe html insertion
         return String(str).replace(/[&<>"]/g, (ch) => { //(replace &,<,>," with entities)
                 if (ch === '&') { return '&amp;'; }
@@ -363,3 +365,4 @@ module.exports.analyzeError = analyzeError;
 module.exports.axiosInstance = axiosInstance; //export axios instance for testing
 module.exports.postWithRetry = postWithRetry; //export retry helper for tests
 module.exports.getQueueRejectCount = getQueueRejectCount; //export queue reject count
+module.exports.clearAdviceCache = clearAdviceCache; //export cache clearing function

--- a/test/clearCache.test.js
+++ b/test/clearCache.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //strict assertions
+const qtests = require('qtests'); //helper for stubbing
+
+function withOpenAIToken(token) { //temporarily modify OPENAI_TOKEN
+  const orig = process.env.OPENAI_TOKEN; //remember current token
+  if (token === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = token; }
+  return () => { if (orig === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = orig; } };
+}
+
+function reloadQerrors() { //load qerrors fresh with current env
+  delete require.cache[require.resolve('../lib/qerrors')];
+  return require('../lib/qerrors');
+}
+
+test('clearAdviceCache empties cache', async () => {
+  const restoreToken = withOpenAIToken('cache-token'); //set token for analysis
+  const origLimit = process.env.QERRORS_CACHE_LIMIT; //save env limit
+  process.env.QERRORS_CACHE_LIMIT = '2'; //ensure caching enabled
+  const qerrors = reloadQerrors(); //reload module
+  const { analyzeError, axiosInstance } = qerrors; //extract functions
+  const restoreAxios = qtests.stubMethod(axiosInstance, 'post', async () => ({ data: { choices: [{ message: { content: { info: 'one' } } }] } }));
+  try {
+    const err = new Error('boom');
+    err.stack = 'stack';
+    err.uniqueErrorName = 'CACHECLR';
+    const first = await analyzeError(err, 'ctx');
+    assert.equal(first.info, 'one');
+    restoreAxios(); //restore first stub
+    let calledAgain = false;
+    const restoreAxios2 = qtests.stubMethod(axiosInstance, 'post', async () => { calledAgain = true; return { data: { choices: [{ message: { content: { info: 'two' } } }] } }; });
+    await analyzeError(err, 'ctx');
+    assert.equal(calledAgain, false); //should use cache
+    qerrors.clearAdviceCache(); //reset cache
+    const afterClear = await analyzeError(err, 'ctx');
+    restoreAxios2();
+    assert.equal(afterClear.info, 'two'); //axios called again
+    assert.equal(calledAgain, true); //verify second stub ran
+  } finally {
+    if (origLimit === undefined) { delete process.env.QERRORS_CACHE_LIMIT; } else { process.env.QERRORS_CACHE_LIMIT = origLimit; }
+    restoreToken();
+    reloadQerrors();
+  }
+});


### PR DESCRIPTION
## Summary
- document manual advice cache clearing in README
- implement `clearAdviceCache()` in lib/qerrors.js
- export the new cache clearing function
- test clearing the advice cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843dc52ecd48322b5cb589fb0d11d19