### PR TITLE
Handle mkdir errors

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -23,7 +23,11 @@ const DailyRotateFile = require('winston-daily-rotate-file'); //import daily rot
 const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 * 1024, maxFiles: Number(process.env.QERRORS_LOG_MAXFILES) || 5, tailable: true }; //(use env config when rotating logs)
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
-fs.mkdirSync(logDir, { recursive: true }); //create logDir before using transports
+let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
+try { fs.mkdirSync(logDir, { recursive: true }); } catch (err) { //(make directory if possible)
+        console.error(`Failed to create log directory ${logDir}: ${err.message}`); //log mkdir error concisely
+        disableFileLogs = true; //skip file transports when mkdir fails
+}
 
 
 
@@ -80,7 +84,7 @@ const logger = createLogger({
         // Multi-transport configuration for comprehensive log coverage
         transports: (() => {
                const arr = []; //start with no transports
-               if (!process.env.QERRORS_DISABLE_FILE_LOGS) { //add files when not disabled
+               if (!disableFileLogs) { //add files when directory available
                         if (maxDays > 0) { //use daily rotate when retention set
                                 arr.push(new DailyRotateFile({ filename: path.join(logDir, 'error-%DATE%.log'), level: 'error', datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize }));
                                 arr.push(new DailyRotateFile({ filename: path.join(logDir, 'combined-%DATE%.log'), datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize }));


### PR DESCRIPTION
## Summary
- handle errors when creating log directory
- fallback to console-only transports
- test logger mkdir failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843efeba7a48322b7d319ab4bd4d3df