### PR TITLE
Async logger init

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,10 +24,11 @@ const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
-try { fs.mkdirSync(logDir, { recursive: true }); } catch (err) { //(make directory if possible)
-        console.error(`Failed to create log directory ${logDir}: ${err.message}`); //log mkdir error concisely
-        disableFileLogs = true; //skip file transports when mkdir fails
+async function initLogDir() { //prepare log directory asynchronously
+        try { await fs.promises.mkdir(logDir, { recursive: true }); } //(attempt mkdir non-blocking)
+        catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(record failure)
 }
+const initPromise = initLogDir(); //start initialization before logger creation
 
 
 
@@ -106,3 +107,4 @@ function logReturn(name, data) { logger.info(`${name} return ${JSON.stringify(da
 module.exports = logger;
 module.exports.logStart = logStart; //export start logger //(make available to env utils)
 module.exports.logReturn = logReturn; //export return logger //(make available to env utils)
+module.exports.initPromise = initPromise; //export initialization completion promise //(enable awaiting)


### PR DESCRIPTION
## Summary
- async initialization for log directory using `fs.promises.mkdir`
- expose initialization promise for logger
- adapt logger test for async init

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843f601764c8322af41c49f14f118fa