### PR TITLE
Add cache TTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic).
 
 * `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching).
+* `QERRORS_CACHE_TTL` &ndash; seconds before cached advice expires (default `86400`).
 * `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load). //(note queue tuning for traffic)
 
 
@@ -56,7 +57,7 @@ You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](
 The retry behaviour can be tuned with QERRORS_RETRY_ATTEMPTS and QERRORS_RETRY_BASE_MS which default to 2 and 100 respectively. //(document retry env vars)
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
-You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50).
+You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50). Use `QERRORS_CACHE_TTL` to control how long each entry stays valid in seconds (default is 86400).
 
 Additional options control the logger's file rotation:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@
 const defaults = { //default environment variable values
   QERRORS_CONCURRENCY: '5', //max concurrent analyses
   QERRORS_CACHE_LIMIT: '50', //LRU cache size
+  QERRORS_CACHE_TTL: '86400', //seconds each cache entry remains valid //(new default ttl)
   QERRORS_QUEUE_LIMIT: '100', //max waiting analyses before rejecting //(new env default)
 
   QERRORS_RETRY_ATTEMPTS: '2', //number of API retries //(renamed env var and updated default)

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -35,8 +35,9 @@ const QUEUE_LIMIT = config.getInt('QERRORS_QUEUE_LIMIT'); //store queue limit at
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit
+const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
-const adviceCache = new Map(); //Map used for LRU cache implementation
+const adviceCache = new Map(); //Map used for LRU cache implementation with timestamps //(cache map)
 
 let warnedMissingToken = false; //track if missing token message already logged
 
@@ -127,11 +128,14 @@ async function analyzeError(error, context) {
         }
 
         if (ADVICE_CACHE_LIMIT !== 0 && adviceCache.has(error.qerrorsKey)) { //skip api call when caching enabled and hit
-                const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry
-                adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
-                adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
-                verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
-                return cached; //return cached advice
+                const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry object
+                if (CACHE_TTL_SECONDS === 0 || Date.now() - cached.ts < CACHE_TTL_SECONDS * 1000) { //validate ttl
+                        adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
+                        adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
+                        verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
+                        return cached.advice; //return cached advice value
+                }
+                adviceCache.delete(error.qerrorsKey); //remove expired entry
         }
 
         // Graceful degradation when API token is not available
@@ -203,7 +207,7 @@ async function analyzeError(error, context) {
                 if (advice.data) {
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
                         if (ADVICE_CACHE_LIMIT !== 0) { //only cache when limit not zero
-                                adviceCache.set(error.qerrorsKey, advice); //store new advice in cache
+                                adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //store advice with timestamp
                                 if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
                         }
                         return advice;
@@ -211,7 +215,7 @@ async function analyzeError(error, context) {
                         // Handle direct advice object
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
                         if (ADVICE_CACHE_LIMIT !== 0) { //cache only if enabled
-                                adviceCache.set(error.qerrorsKey, advice); //cache direct advice
+                                adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //cache direct advice with timestamp
                                 if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
                         }
                         return advice;


### PR DESCRIPTION
## Summary
- add new `QERRORS_CACHE_TTL` env var defaulting to 86400 seconds
- store timestamps on cached advice and expire entries when they exceed TTL
- document the new environment variable in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843f609c5b88322824f5decfeb3770f