### PR TITLE
Add warning for high queue limits

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -32,6 +32,9 @@ function verboseLog(msg) { //conditional console output helper
 const CONCURRENCY_LIMIT = config.getInt('QERRORS_CONCURRENCY'); //store concurrency at module load
 const QUEUE_LIMIT = config.getInt('QERRORS_QUEUE_LIMIT'); //store queue limit at module load
 
+const SAFE_THRESHOLD = 1000; //limit considered safe for concurrency and queue
+if (CONCURRENCY_LIMIT > SAFE_THRESHOLD || QUEUE_LIMIT > SAFE_THRESHOLD) { logger.warn(`High qerrors limits conc ${CONCURRENCY_LIMIT} queue ${QUEUE_LIMIT}`); } //(warn when limits exceed threshold)
+
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit

--- a/test/initWarn.test.js
+++ b/test/initWarn.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stub helper
+
+function loadQerrors() {
+  delete require.cache[require.resolve('../lib/qerrors')];
+  return require('../lib/qerrors');
+}
+
+test('warn when limits exceed safe threshold', () => {
+  const origConc = process.env.QERRORS_CONCURRENCY; //backup concurrency
+  const origQueue = process.env.QERRORS_QUEUE_LIMIT; //backup queue limit
+  process.env.QERRORS_CONCURRENCY = '2000'; //excessive concurrency
+  process.env.QERRORS_QUEUE_LIMIT = '2000'; //excessive queue
+  const logger = require('../lib/logger'); //logger instance
+  let warned = false; //track warn calls
+  const restoreWarn = qtests.stubMethod(logger, 'warn', () => { warned = true; });
+  try {
+    loadQerrors(); //module initialization triggers warning
+  } finally {
+    restoreWarn(); //restore logger.warn
+    if (origConc === undefined) { delete process.env.QERRORS_CONCURRENCY; } else { process.env.QERRORS_CONCURRENCY = origConc; }
+    if (origQueue === undefined) { delete process.env.QERRORS_QUEUE_LIMIT; } else { process.env.QERRORS_QUEUE_LIMIT = origQueue; }
+    delete require.cache[require.resolve('../lib/qerrors')]; //reset module
+    require('../lib/qerrors'); //reload defaults
+  }
+  assert.equal(warned, true); //expect warning emitted
+});


### PR DESCRIPTION
## Summary
- warn if configured concurrency or queue limits exceed 1000
- test warning when limits are high

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843f6108d9c83228fdf4694fa28a003