### PR TITLE
Add cache TTL purge to qerrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Whenever the queue rejects an analysis the module increments an internal counter
 Check it with `qerrors.getQueueRejectCount()`. //(usage note)
 
 Call `qerrors.clearAdviceCache()` to manually empty the advice cache. //(document cache clearing)
+Call `qerrors.purgeExpiredAdvice()` to drop stale entries based on the TTL. //(document cleanup)
 
 Use `qerrors.getQueueLength()` to monitor how many analyses are waiting. //(mention queue length)
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -59,6 +59,7 @@ let queueRejectCount = 0; //track how many analyses the queue rejects
 
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
+        purgeExpiredAdvice(); //remove expired cache entries before queuing
         if (limit.pendingCount >= QUEUE_LIMIT) { queueRejectCount++; logger.warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } // (reject when pending count hits limit)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 
@@ -68,6 +69,14 @@ function getQueueRejectCount() { return queueRejectCount; } //expose reject coun
 
 
 function clearAdviceCache() { adviceCache.clear(); } //empty the advice cache map
+
+function purgeExpiredAdvice() { //drop expired advice entries
+        if (CACHE_TTL_SECONDS === 0) { return; } //skip when ttl disabled
+        const now = Date.now(); //current time for comparisons
+        for (const [key, val] of adviceCache) { //iterate over cache items
+                if (now - val.ts > CACHE_TTL_SECONDS * 1000) { adviceCache.delete(key); } //delete when older than ttl
+        }
+} //remove cache entries past TTL
 
 function getQueueLength() { return limit.pendingCount; } //expose queue length
 
@@ -378,6 +387,7 @@ module.exports.postWithRetry = postWithRetry; //export retry helper for tests
 module.exports.getQueueRejectCount = getQueueRejectCount; //export queue reject count
 
 module.exports.clearAdviceCache = clearAdviceCache; //export cache clearing function
+module.exports.purgeExpiredAdvice = purgeExpiredAdvice; //export ttl cleanup function
 
 module.exports.getQueueLength = getQueueLength; //export queue length
 


### PR DESCRIPTION
## Summary
- purge expired advice from cache
- clean cache before queuing analysis
- document new TTL purge helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684498d7dffc83228749bfdd5fbc67be