### PR TITLE
Implement periodic advice cache cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Whenever the queue rejects an analysis the module increments an internal counter
 Check it with `qerrors.getQueueRejectCount()`. //(usage note)
 
 Call `qerrors.clearAdviceCache()` to manually empty the advice cache. //(document cache clearing)
-Call `qerrors.purgeExpiredAdvice()` to drop stale entries based on the TTL. //(document cleanup)
+Use `qerrors.startAdviceCleanup()` to begin automatic purging of expired entries. //(document cleanup scheduler)
+Call `qerrors.stopAdviceCleanup()` if you need to halt the cleanup interval. //(document cleanup stop)
+Call `qerrors.purgeExpiredAdvice()` to run a purge instantly. //(manual purge reminder)
 
 Use `qerrors.getQueueLength()` to monitor how many analyses are waiting. //(mention queue length)
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -55,11 +55,24 @@ const axiosInstance = axios.create({ //axios instance with keep alive agents
 const limit = pLimit(CONCURRENCY_LIMIT); //create limiter with stored concurrency
 
 let queueRejectCount = 0; //track how many analyses the queue rejects
+let cleanupHandle = null; //hold interval id for periodic cache purge
+
+function startAdviceCleanup() { //(kick off periodic advice cleanup)
+        if (CACHE_TTL_SECONDS === 0 || cleanupHandle) { return; } //(skip when ttl off or already scheduled)
+        cleanupHandle = setInterval(purgeExpiredAdvice, CACHE_TTL_SECONDS * 1000); //(run purge at ttl interval)
+        cleanupHandle.unref(); //(allow process exit without clearing interval)
+}
+
+function stopAdviceCleanup() { //(stop periodic purge when needed)
+        if (!cleanupHandle) { return; } //(do nothing when no interval)
+        clearInterval(cleanupHandle); //(cancel interval)
+        cleanupHandle = null; //(reset handle state)
+}
 
 
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
-        purgeExpiredAdvice(); //remove expired cache entries before queuing
+        startAdviceCleanup(); //(ensure cleanup interval scheduled once)
         if (limit.pendingCount >= QUEUE_LIMIT) { queueRejectCount++; logger.warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } // (reject when pending count hits limit)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 
@@ -70,13 +83,19 @@ function getQueueRejectCount() { return queueRejectCount; } //expose reject coun
 
 function clearAdviceCache() { adviceCache.clear(); } //empty the advice cache map
 
-function purgeExpiredAdvice() { //drop expired advice entries
-        if (CACHE_TTL_SECONDS === 0) { return; } //skip when ttl disabled
+let purgeIterator = null; //iterator to scan cache incrementally
+
+function purgeExpiredAdvice(batch = 50) { //drop expired advice entries in pieces
+        if (CACHE_TTL_SECONDS === 0 || adviceCache.size === 0) { return; } //skip when ttl disabled or cache empty
+        if (!purgeIterator) { purgeIterator = adviceCache.entries(); } //(init iterator on first call)
         const now = Date.now(); //current time for comparisons
-        for (const [key, val] of adviceCache) { //iterate over cache items
+        for (let i = 0; i < batch; i++) { //scan limited entries per run
+                const next = purgeIterator.next(); //fetch next cache item
+                if (next.done) { purgeIterator = null; break; } //(reset when traversal complete)
+                const [key, val] = next.value; //item pair from map
                 if (now - val.ts > CACHE_TTL_SECONDS * 1000) { adviceCache.delete(key); } //delete when older than ttl
         }
-} //remove cache entries past TTL
+} //remove up to batch entries past TTL per call
 
 function getQueueLength() { return limit.pendingCount; } //expose queue length
 
@@ -388,6 +407,8 @@ module.exports.getQueueRejectCount = getQueueRejectCount; //export queue reject 
 
 module.exports.clearAdviceCache = clearAdviceCache; //export cache clearing function
 module.exports.purgeExpiredAdvice = purgeExpiredAdvice; //export ttl cleanup function
+module.exports.startAdviceCleanup = startAdviceCleanup; //export cleanup scheduler
+module.exports.stopAdviceCleanup = stopAdviceCleanup; //export cleanup canceller
 
 module.exports.getQueueLength = getQueueLength; //export queue length
 


### PR DESCRIPTION
## Summary
- add periodic cleanup with `startAdviceCleanup`/`stopAdviceCleanup`
- schedule purge in `scheduleAnalysis`
- iterate cache in small batches
- document new cleanup functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a2e11b78832290fb369bf3804e96