### PR TITLE
Fix logger initialization order

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,11 +24,16 @@ const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
+function initLogDirSync() { //ensure log directory synchronously
+        try { fs.mkdirSync(logDir, { recursive: true }); } //(make directory blocking)
+        catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(log and disable files)
+}
 async function initLogDir() { //prepare log directory asynchronously
-        try { await fs.promises.mkdir(logDir, { recursive: true }); } //(attempt mkdir non-blocking)
+        try { await fs.promises.mkdir(logDir, { recursive: true }); } //(create dir async for tests)
         catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(record failure)
 }
-const initPromise = initLogDir(); //start initialization before logger creation
+initLogDirSync(); //create directory before logger
+const initPromise = initLogDir(); //continue async init for error reporting
 
 
 


### PR DESCRIPTION
## Summary
- ensure log directory exists before creating the logger
- keep async directory creation for tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844a2e1e2e483228a4d44cc576613e9