### PR TITLE
Clamp concurrency and queue limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ to resolve errors.
 qerrors reads several environment variables to tune its behavior. A small configuration file in the library sets sensible defaults when these variables are not defined. Only `OPENAI_TOKEN` must be provided manually to enable AI analysis.
 
 * `OPENAI_TOKEN` &ndash; your OpenAI API key.
-* `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic).
+* `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic, values over `1000` are clamped). //(document clamp)
 
 * `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching).
 * `QERRORS_CACHE_TTL` &ndash; seconds before cached advice expires (default `86400`).
-* `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load). //(note queue tuning for traffic)
+* `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load, values over `1000` are clamped). //(document queue clamp)
 
 
 * `QERRORS_RETRY_ATTEMPTS` &ndash; attempts when calling OpenAI (default `2`).

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -29,11 +29,13 @@ function verboseLog(msg) { //conditional console output helper
         if (config.getEnv('QERRORS_VERBOSE') === 'true') console.log(msg); //only log when enabled
 }
 
-const CONCURRENCY_LIMIT = config.getInt('QERRORS_CONCURRENCY'); //store concurrency at module load
-const QUEUE_LIMIT = config.getInt('QERRORS_QUEUE_LIMIT'); //store queue limit at module load
+const rawConc = config.getInt('QERRORS_CONCURRENCY'); //(raw concurrency from env)
+const rawQueue = config.getInt('QERRORS_QUEUE_LIMIT'); //(raw queue limit from env)
 
 const SAFE_THRESHOLD = 1000; //limit considered safe for concurrency and queue
-if (CONCURRENCY_LIMIT > SAFE_THRESHOLD || QUEUE_LIMIT > SAFE_THRESHOLD) { logger.warn(`High qerrors limits conc ${CONCURRENCY_LIMIT} queue ${QUEUE_LIMIT}`); } //(warn when limits exceed threshold)
+const CONCURRENCY_LIMIT = Math.min(rawConc, SAFE_THRESHOLD); //(clamp concurrency to safe threshold)
+const QUEUE_LIMIT = Math.min(rawQueue, SAFE_THRESHOLD); //(clamp queue limit to safe threshold)
+if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`); } //(warn when original limits exceed threshold)
 
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed


### PR DESCRIPTION
## Summary
- clamp `QERRORS_CONCURRENCY` and `QERRORS_QUEUE_LIMIT` above a SAFE_THRESHOLD
- document env var clamping in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a2e449e08322a3004c54efd8a122