### PR TITLE
Add backoff cap to postWithRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 
 * `QERRORS_RETRY_ATTEMPTS` &ndash; attempts when calling OpenAI (default `2`).
 * `QERRORS_RETRY_BASE_MS` &ndash; base delay in ms for retries (default `100`).
+* `QERRORS_RETRY_MAX_MS` &ndash; cap on retry backoff in ms (default `2000`).
 * `QERRORS_TIMEOUT` &ndash; axios request timeout in ms (default `10000`).
 * `QERRORS_MAX_SOCKETS` &ndash; maximum sockets per agent (default `50`, increase for high traffic).
 
@@ -55,7 +56,7 @@ if not set the default is 50; raise this to handle high traffic. //state default
 
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com). //(mention required token)
-The retry behaviour can be tuned with QERRORS_RETRY_ATTEMPTS and QERRORS_RETRY_BASE_MS which default to 2 and 100 respectively. //(document retry env vars)
+The retry behaviour can be tuned with QERRORS_RETRY_ATTEMPTS, QERRORS_RETRY_BASE_MS and QERRORS_RETRY_MAX_MS which default to 2, 100 and 2000 respectively. //(document retry env vars)
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
 You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50). Use `QERRORS_CACHE_TTL` to control how long each entry stays valid in seconds (default is 86400).

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,7 @@ const defaults = { //default environment variable values
 
   QERRORS_RETRY_ATTEMPTS: '2', //number of API retries //(renamed env var and updated default)
   QERRORS_RETRY_BASE_MS: '100', //base delay for retries //(renamed env var and updated default)
+  QERRORS_RETRY_MAX_MS: '2000', //cap wait time for exponential backoff //(new env default)
   QERRORS_TIMEOUT: '10000', //axios request timeout in ms
   QERRORS_MAX_SOCKETS: '50', //max sockets per http/https agent
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -91,14 +91,16 @@ function escapeHtml(str) { //escape characters for safe html insertion
         });
 }
 
-async function postWithRetry(url, data, opts) { //post wrapper with retry logic
+async function postWithRetry(url, data, opts, capMs) { //post wrapper with retry logic and cap
         const retries = config.getInt('QERRORS_RETRY_ATTEMPTS'); //default retry count
         const base = config.getInt('QERRORS_RETRY_BASE_MS'); //base delay ms
+        const cap = capMs !== undefined ? capMs : config.getInt('QERRORS_RETRY_MAX_MS', 0); //choose cap
         for (let i = 0; i <= retries; i++) { //attempt request with retries
                 try { return await axiosInstance.post(url, data, opts); } //(try post once)
                 catch (err) { if (i >= retries) throw err; } //throw when out of retries
                 const jitter = Math.random() * base; //random jitter added to delay
-                const wait = base * 2 ** i + jitter; //compute exponential delay with jitter
+                let wait = base * 2 ** i + jitter; //compute exponential delay with jitter
+                if (cap > 0 && wait > cap) { wait = cap; } //enforce cap when provided
                 await new Promise(r => setTimeout(r, wait)); //pause before next attempt
         }
 }

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -26,14 +26,17 @@ function withOpenAIToken(token) { //(temporarily set OPENAI_TOKEN)
   };
 }
 
-function withRetryEnv(retry, base) { //(temporarily set retry env vars)
+function withRetryEnv(retry, base, max) { //(temporarily set retry env vars)
   const origRetry = process.env.QERRORS_RETRY_ATTEMPTS; //(store original attempts)
   const origBase = process.env.QERRORS_RETRY_BASE_MS; //(store original delay)
+  const origMax = process.env.QERRORS_RETRY_MAX_MS; //(store original cap)
   if (retry === undefined) { delete process.env.QERRORS_RETRY_ATTEMPTS; } else { process.env.QERRORS_RETRY_ATTEMPTS = String(retry); } //(apply retry)
   if (base === undefined) { delete process.env.QERRORS_RETRY_BASE_MS; } else { process.env.QERRORS_RETRY_BASE_MS = String(base); } //(apply delay)
+  if (max === undefined) { delete process.env.QERRORS_RETRY_MAX_MS; } else { process.env.QERRORS_RETRY_MAX_MS = String(max); } //(apply cap)
   return () => { //(restore both variables)
     if (origRetry === undefined) { delete process.env.QERRORS_RETRY_ATTEMPTS; } else { process.env.QERRORS_RETRY_ATTEMPTS = origRetry; }
     if (origBase === undefined) { delete process.env.QERRORS_RETRY_BASE_MS; } else { process.env.QERRORS_RETRY_BASE_MS = origBase; }
+    if (origMax === undefined) { delete process.env.QERRORS_RETRY_MAX_MS; } else { process.env.QERRORS_RETRY_MAX_MS = origMax; }
   };
 }
 

--- a/test/postWithRetry.test.js
+++ b/test/postWithRetry.test.js
@@ -5,14 +5,17 @@ const qtests = require('qtests'); //stub utility
 const qerrorsModule = require('../lib/qerrors'); //module under test
 const { postWithRetry, axiosInstance } = qerrorsModule; //target helper and axios
 
-function withRetryEnv(retry, base) { //temporarily set retry env vars
+function withRetryEnv(retry, base, max) { //temporarily set retry env vars
   const origRetry = process.env.QERRORS_RETRY_ATTEMPTS; //save attempts
   const origBase = process.env.QERRORS_RETRY_BASE_MS; //save base delay
+  const origMax = process.env.QERRORS_RETRY_MAX_MS; //save cap delay
   if (retry === undefined) { delete process.env.QERRORS_RETRY_ATTEMPTS; } else { process.env.QERRORS_RETRY_ATTEMPTS = String(retry); }
   if (base === undefined) { delete process.env.QERRORS_RETRY_BASE_MS; } else { process.env.QERRORS_RETRY_BASE_MS = String(base); }
+  if (max === undefined) { delete process.env.QERRORS_RETRY_MAX_MS; } else { process.env.QERRORS_RETRY_MAX_MS = String(max); }
   return () => { //restore env vars
     if (origRetry === undefined) { delete process.env.QERRORS_RETRY_ATTEMPTS; } else { process.env.QERRORS_RETRY_ATTEMPTS = origRetry; }
     if (origBase === undefined) { delete process.env.QERRORS_RETRY_BASE_MS; } else { process.env.QERRORS_RETRY_BASE_MS = origBase; }
+    if (origMax === undefined) { delete process.env.QERRORS_RETRY_MAX_MS; } else { process.env.QERRORS_RETRY_MAX_MS = origMax; }
   };
 }
 
@@ -63,5 +66,29 @@ test('postWithRetry uses defaults with invalid env', async () => { //invalid val
     restoreTimeout(); //restore timeout
     restoreAxios(); //restore axios
     restoreEnv(); //restore env vars
+  }
+});
+
+test('postWithRetry enforces backoff cap', async () => { //cap ensures wait time not excessive
+  const restoreEnv = withRetryEnv(1, 300, 400); //set base and cap
+  let callCount = 0; //track axios calls
+  const restoreAxios = qtests.stubMethod(axiosInstance, 'post', async () => { //stub post
+    callCount++; //increment each time
+    if (callCount === 1) { throw new Error('fail'); } //fail first
+    return { ok: true }; //succeed second
+  });
+  let waited; //capture capped wait
+  const restoreTimeout = qtests.stubMethod(global, 'setTimeout', (fn, ms) => { waited = ms; fn(); }); //capture delay
+  const origRandom = Math.random; //save random
+  Math.random = () => 0.5; //predictable jitter
+  try {
+    const res = await postWithRetry('url', {}); //invoke helper
+    assert.equal(res.ok, true); //successful result
+    assert.equal(waited, 400); //delay capped at 400
+  } finally {
+    Math.random = origRandom; //restore random
+    restoreTimeout(); //restore timeout
+    restoreAxios(); //restore axios
+    restoreEnv(); //restore env
   }
 });


### PR DESCRIPTION
## Summary
- add QERRORS_RETRY_MAX_MS env var
- cap wait time in postWithRetry
- document new setting and update retry docs
- test backoff cap behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a569d4dc83228d476fb305352e59