### PR TITLE
Add Redis external cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 
 * `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching).
 * `QERRORS_CACHE_TTL` &ndash; seconds before cached advice expires (default `86400`).
+* `QERRORS_REDIS_URL` &ndash; Redis connection string for cross process caching (optional).
 * `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load). //(note queue tuning for traffic)
 
 
@@ -59,6 +60,7 @@ The retry behaviour can be tuned with QERRORS_RETRY_ATTEMPTS and QERRORS_RETRY_B
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
 You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50). Use `QERRORS_CACHE_TTL` to control how long each entry stays valid in seconds (default is 86400).
+Specify `QERRORS_REDIS_URL` to enable shared caching across Node.js processes when running multiple instances.
 
 Additional options control the logger's file rotation:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ const defaults = { //default environment variable values
   QERRORS_CONCURRENCY: '5', //max concurrent analyses
   QERRORS_CACHE_LIMIT: '50', //LRU cache size
   QERRORS_CACHE_TTL: '86400', //seconds each cache entry remains valid //(new default ttl)
+  QERRORS_REDIS_URL: '', //external redis connection string //(new redis env var)
   QERRORS_QUEUE_LIMIT: '100', //max waiting analyses before rejecting //(new env default)
 
   QERRORS_RETRY_ATTEMPTS: '2', //number of API retries //(renamed env var and updated default)

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -23,6 +23,7 @@ const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 const { randomUUID } = require('crypto'); //import UUID generator for unique names
 const pLimit = require('p-limit'); //lightweight promise queue for concurrency control
+const { createClient } = require('redis'); //redis client for optional external cache
 
 
 function verboseLog(msg) { //conditional console output helper
@@ -41,6 +42,14 @@ const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cac
 const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
 const adviceCache = new Map(); //Map used for LRU cache implementation with timestamps //(cache map)
+
+const REDIS_URL = config.getEnv('QERRORS_REDIS_URL'); //connection string for redis cache //(new variable)
+let redisClient = null; //holds redis client instance when configured //(new variable)
+if (REDIS_URL) { //initialize redis when url provided
+        redisClient = createClient({ url: REDIS_URL }); //create client with url
+        redisClient.on('error', err => console.error(`redis error ${err.message}`)); //log redis errors
+        redisClient.connect().catch(err => { console.error(`redis connect failed ${err.message}`); redisClient = null; }); //attempt connection
+}
 
 let warnedMissingToken = false; //track if missing token message already logged
 
@@ -69,6 +78,20 @@ function getQueueRejectCount() { return queueRejectCount; } //expose reject coun
 
 
 function clearAdviceCache() { adviceCache.clear(); } //empty the advice cache map
+
+async function redisGet(key) { //fetch cached advice from redis when configured
+        if (!redisClient) { return null; } //skip when redis disabled
+        try { const val = await redisClient.get(key); return val ? JSON.parse(val) : null; } //parse stored json
+        catch (err) { console.error(`redis get failed ${err.message}`); return null; } //log and ignore errors
+}
+
+async function redisSet(key, advice) { //store advice in redis when configured
+        if (!redisClient) { return; } //skip when redis disabled
+        try {
+                const opts = CACHE_TTL_SECONDS === 0 ? {} : { EX: CACHE_TTL_SECONDS }; //expire using ttl
+                await redisClient.set(key, JSON.stringify(advice), opts); //save json string with ttl
+        } catch (err) { console.error(`redis set failed ${err.message}`); } //log error but do not throw
+}
 
 function purgeExpiredAdvice() { //drop expired advice entries
         if (CACHE_TTL_SECONDS === 0) { return; } //skip when ttl disabled
@@ -139,15 +162,25 @@ async function analyzeError(error, context) {
                 error.qerrorsKey = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //hash message and stack for caching
         }
 
-        if (ADVICE_CACHE_LIMIT !== 0 && adviceCache.has(error.qerrorsKey)) { //skip api call when caching enabled and hit
-                const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry object
-                if (CACHE_TTL_SECONDS === 0 || Date.now() - cached.ts < CACHE_TTL_SECONDS * 1000) { //validate ttl
-                        adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
-                        adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
-                        verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
-                        return cached.advice; //return cached advice value
+        if (ADVICE_CACHE_LIMIT !== 0) { //use cache when enabled
+                if (redisClient) { //check external store first
+                        const rCached = await redisGet(error.qerrorsKey); //load from redis
+                        if (rCached) { //return when redis hit
+                                adviceCache.set(error.qerrorsKey, { advice: rCached, ts: Date.now() }); //sync memory cache
+                                verboseLog(`redis hit for ${error.uniqueErrorName}`); //log redis usage
+                                return rCached; //return cached advice from redis
+                        }
                 }
-                adviceCache.delete(error.qerrorsKey); //remove expired entry
+                if (adviceCache.has(error.qerrorsKey)) { //check memory cache next
+                        const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry object
+                        if (CACHE_TTL_SECONDS === 0 || Date.now() - cached.ts < CACHE_TTL_SECONDS * 1000) { //validate ttl
+                                adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
+                                adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
+                                verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
+                                return cached.advice; //return cached advice value
+                        }
+                        adviceCache.delete(error.qerrorsKey); //remove expired entry
+                }
         }
 
         // Graceful degradation when API token is not available
@@ -221,6 +254,7 @@ async function analyzeError(error, context) {
                         if (ADVICE_CACHE_LIMIT !== 0) { //only cache when limit not zero
                                 adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //store advice with timestamp
                                 if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
+                                redisSet(error.qerrorsKey, advice); //persist advice in redis when configured
                         }
                         return advice;
                 } else if (advice) {
@@ -229,6 +263,7 @@ async function analyzeError(error, context) {
                         if (ADVICE_CACHE_LIMIT !== 0) { //cache only if enabled
                                 adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //cache direct advice with timestamp
                                 if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
+                                redisSet(error.qerrorsKey, advice); //save advice in redis when configured
                         }
                         return advice;
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.9.0",
         "p-limit": "^4.0.0",
         "qtests": "^1.0.2",
-        "winston": "^3.13.0"
+        "winston": "^3.13.0",
+        "redis": "^4.6.7"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "axios": "^1.9.0",
     "p-limit": "^4.0.0",
     "qtests": "^1.0.2",
-    "winston": "^3.13.0"
+    "winston": "^3.13.0",
+    "redis": "^4.6.7"
   },
   "directories": {
     "lib": "lib"

--- a/stubs/redis.js
+++ b/stubs/redis.js
@@ -1,0 +1,15 @@
+let createdOptions = null; //options passed to createClient
+let lastClient = null; //expose most recent client instance for assertions
+function createClient(opts = {}) { //mimic redis.createClient
+  createdOptions = opts; //store options for test assertions
+  lastClient = {
+    store: new Map(), //simple in-memory store
+    lastSetOpts: null, //capture options from set
+    async connect() {}, //no-op async connect
+    on() {}, //no-op listener
+    async get(key) { return this.store.has(key) ? this.store.get(key) : null; }, //return value or null
+    async set(key, val, opts) { this.store.set(key, val); this.lastSetOpts = opts; }, //save value with opts
+  };
+  return lastClient; //return client instance
+}
+module.exports = { createClient, createdOptions, get lastClient() { return lastClient; } }; //expose for tests with getter

--- a/test/externalCache.test.js
+++ b/test/externalCache.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+
+function reloadQerrors() { //reload qerrors module for env changes
+  delete require.cache[require.resolve('../lib/qerrors')];
+  return require('../lib/qerrors');
+}
+
+function withRedis(url) { //temporarily set redis url
+  const orig = process.env.QERRORS_REDIS_URL;
+  if (url === undefined) { delete process.env.QERRORS_REDIS_URL; } else { process.env.QERRORS_REDIS_URL = url; }
+  return () => { if (orig === undefined) { delete process.env.QERRORS_REDIS_URL; } else { process.env.QERRORS_REDIS_URL = orig; } };
+}
+
+function withToken() { const orig = process.env.OPENAI_TOKEN; process.env.OPENAI_TOKEN = 'tkn'; return () => { if (orig === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = orig; } }; }
+
+test('analyzeError uses redis cache when configured', async () => {
+  const restoreToken = withToken();
+  const restoreRedis = withRedis('redis://test');
+  const qerrors = reloadQerrors();
+  const { analyzeError, axiosInstance, clearAdviceCache } = qerrors;
+  const redis = require('redis');
+  const restoreAxios = qtests.stubMethod(axiosInstance, 'post', async () => ({ data: { choices: [{ message: { content: { msg: 'r' } } }] } }));
+  try {
+    const err = new Error('boom');
+    err.stack = 'stack';
+    err.uniqueErrorName = 'REDIS1';
+    const first = await analyzeError(err, 'ctx');
+    assert.equal(first.msg, 'r');
+    clearAdviceCache();
+    let called = false;
+    const restoreAxios2 = qtests.stubMethod(axiosInstance, 'post', async () => { called = true; return {}; });
+    const again = await analyzeError(err, 'ctx');
+    restoreAxios2();
+    assert.equal(called, false);
+    assert.equal(again.msg, 'r');
+    assert.equal(redis.lastClient.store.get(err.qerrorsKey) !== undefined, true);
+  } finally {
+    restoreAxios();
+    restoreRedis();
+    restoreToken();
+    reloadQerrors();
+  }
+});


### PR DESCRIPTION
## Summary
- support external Redis caching through `QERRORS_REDIS_URL`
- wire Redis client into `lib/qerrors.js`
- update README for new env var
- add Redis stub and tests for external caching
- include redis dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a56c31788322af51629c686032be