### PR TITLE
Optimize TTL purge

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -41,6 +41,7 @@ const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cac
 const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
 const adviceCache = new Map(); //Map used for LRU cache implementation with timestamps //(cache map)
+const expiryQueue = []; //fifo queue storing cache key expirations //(track TTL)
 
 let warnedMissingToken = false; //track if missing token message already logged
 
@@ -68,15 +69,17 @@ async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
 function getQueueRejectCount() { return queueRejectCount; } //expose reject count
 
 
-function clearAdviceCache() { adviceCache.clear(); } //empty the advice cache map
+function clearAdviceCache() { adviceCache.clear(); expiryQueue.length = 0; } //empty the advice cache map and queue
 
 function purgeExpiredAdvice() { //drop expired advice entries
         if (CACHE_TTL_SECONDS === 0) { return; } //skip when ttl disabled
         const now = Date.now(); //current time for comparisons
-        for (const [key, val] of adviceCache) { //iterate over cache items
-                if (now - val.ts > CACHE_TTL_SECONDS * 1000) { adviceCache.delete(key); } //delete when older than ttl
+        while (expiryQueue.length && expiryQueue[0].expire <= now) { //check queue head for expiry
+                const { key } = expiryQueue.shift(); //remove queue head for expired item
+                const item = adviceCache.get(key); //fetch cached entry
+                if (item && now - item.ts > CACHE_TTL_SECONDS * 1000) { adviceCache.delete(key); } //delete if stale
         }
-} //remove cache entries past TTL
+} //remove cache entries via queue
 
 function getQueueLength() { return limit.pendingCount; } //expose queue length
 
@@ -219,7 +222,9 @@ async function analyzeError(error, context) {
                 if (advice.data) {
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
                         if (ADVICE_CACHE_LIMIT !== 0) { //only cache when limit not zero
-                                adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //store advice with timestamp
+                                const now = Date.now(); //capture current time
+                                adviceCache.set(error.qerrorsKey, { advice, ts: now }); //store advice with timestamp
+                                if (CACHE_TTL_SECONDS !== 0) { expiryQueue.push({ key: error.qerrorsKey, expire: now + CACHE_TTL_SECONDS * 1000 }); } //record ttl expiry
                                 if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
                         }
                         return advice;
@@ -227,7 +232,9 @@ async function analyzeError(error, context) {
                         // Handle direct advice object
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
                         if (ADVICE_CACHE_LIMIT !== 0) { //cache only if enabled
-                                adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //cache direct advice with timestamp
+                                const now = Date.now(); //capture current time
+                                adviceCache.set(error.qerrorsKey, { advice, ts: now }); //cache direct advice with timestamp
+                                if (CACHE_TTL_SECONDS !== 0) { expiryQueue.push({ key: error.qerrorsKey, expire: now + CACHE_TTL_SECONDS * 1000 }); } //record ttl expiry
                                 if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
                         }
                         return advice;

--- a/test/ttlPurge.test.js
+++ b/test/ttlPurge.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+
+function withOpenAIToken(token) { //temporarily set token
+  const orig = process.env.OPENAI_TOKEN; //save original token
+  if (token === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = token; }
+  return () => { if (orig === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = orig; } };
+}
+
+function reloadQerrors() { //reload module with env
+  delete require.cache[require.resolve('../lib/qerrors')];
+  return require('../lib/qerrors');
+}
+
+test('purgeExpiredAdvice removes entries after ttl', async () => {
+  const restoreToken = withOpenAIToken('ttl-token'); //set token for caching
+  const origLimit = process.env.QERRORS_CACHE_LIMIT; //save limit env
+  const origTtl = process.env.QERRORS_CACHE_TTL; //save ttl env
+  process.env.QERRORS_CACHE_LIMIT = '2'; //enable cache
+  process.env.QERRORS_CACHE_TTL = '1'; //short ttl
+  const qerrors = reloadQerrors(); //reload under new env
+  const { analyzeError, axiosInstance, purgeExpiredAdvice } = qerrors; //extract functions
+  const restoreAxios1 = qtests.stubMethod(axiosInstance, 'post', async () => ({ data: { choices: [{ message: { content: { info: 'one' } } }] } }));
+  const err = new Error('boom'); //sample error
+  err.stack = 'stack'; //fake stack trace
+  err.uniqueErrorName = 'TTL'; //set unique name
+  await analyzeError(err, 'ctx'); //populate cache
+  restoreAxios1(); //cleanup first stub
+  let called = false; //track second call
+  const restoreAxios2 = qtests.stubMethod(axiosInstance, 'post', async () => { called = true; return { data: { choices: [{ message: { content: { info: 'two' } } }] } }; });
+  await new Promise(r => setTimeout(r, 1100)); //wait past ttl
+  purgeExpiredAdvice(); //trigger purge
+  await analyzeError(err, 'ctx'); //should hit axios again
+  restoreAxios2(); //restore stub
+  if (origLimit === undefined) { delete process.env.QERRORS_CACHE_LIMIT; } else { process.env.QERRORS_CACHE_LIMIT = origLimit; }
+  if (origTtl === undefined) { delete process.env.QERRORS_CACHE_TTL; } else { process.env.QERRORS_CACHE_TTL = origTtl; }
+  restoreToken(); //restore token
+  reloadQerrors(); //reset module
+  assert.equal(called, true); //verify second axios call
+});


### PR DESCRIPTION
## Summary
- use expiry queue so purgeExpiredAdvice doesn't scan the whole cache
- track each cache entry's expiration time
- clear expiration queue when clearing the cache
- test TTL expiry logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a570253c8322b59279afa2c5df43