### PR TITLE
Ensure logger waits for log directory

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -30,6 +30,9 @@ async function initLogDir() { //prepare log directory asynchronously
 }
 const initPromise = initLogDir(); //start initialization before logger creation
 
+try { fs.mkdirSync(logDir, { recursive: true }); } //(ensure directory before logger init)
+catch (err) { console.error(`Failed sync check of log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(fallback to console only)
+
 
 
 /**


### PR DESCRIPTION
## Summary
- check log directory synchronously after initLogDir
- fall back to console logging if the sync check fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844a5de4db08322bb42b36241e9646a