### PR TITLE
account for active tasks in queue limit

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -75,7 +75,8 @@ function stopAdviceCleanup() { //(stop periodic purge when needed)
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         startAdviceCleanup(); //(ensure cleanup interval scheduled once)
-        if (limit.pendingCount >= QUEUE_LIMIT) { queueRejectCount++; logger.warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } // (reject when pending count hits limit)
+        const total = limit.pendingCount + limit.activeCount; //sum queued and active analyses
+        if (total >= QUEUE_LIMIT) { queueRejectCount++; logger.warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } //(reject when queue limit reached)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 
 }


### PR DESCRIPTION
## Summary
- reject analysis when pending + active reach queue limit
- adjust queue behavior tests for new rejection policy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844acb03b1883229d10129c3178a565