### PR TITLE
Use lru-cache for advice storage

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -23,6 +23,7 @@ const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 const { randomUUID } = require('crypto'); //import UUID generator for unique names
 const pLimit = require('p-limit'); //lightweight promise queue for concurrency control
+const LRU = require('lru-cache'); //LRU cache module replaces manual Map
 
 
 function verboseLog(msg) { //conditional console output helper
@@ -42,7 +43,7 @@ const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with 
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit
 const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
-const adviceCache = new Map(); //Map used for LRU cache implementation with timestamps //(cache map)
+const adviceCache = new LRU({ max: ADVICE_CACHE_LIMIT || 0, ttl: CACHE_TTL_SECONDS * 1000 }); //lru-cache instance using env limits
 
 let warnedMissingToken = false; //track if missing token message already logged
 
@@ -60,7 +61,7 @@ let queueRejectCount = 0; //track how many analyses the queue rejects
 let cleanupHandle = null; //hold interval id for periodic cache purge
 
 function startAdviceCleanup() { //(kick off periodic advice cleanup)
-        if (CACHE_TTL_SECONDS === 0 || cleanupHandle) { return; } //(skip when ttl off or already scheduled)
+        if (CACHE_TTL_SECONDS === 0 || ADVICE_CACHE_LIMIT === 0 || cleanupHandle) { return; } //(skip when ttl or cache disabled or already scheduled)
         cleanupHandle = setInterval(purgeExpiredAdvice, CACHE_TTL_SECONDS * 1000); //(run purge at ttl interval)
         cleanupHandle.unref(); //(allow process exit without clearing interval)
 }
@@ -83,21 +84,12 @@ async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
 function getQueueRejectCount() { return queueRejectCount; } //expose reject count
 
 
-function clearAdviceCache() { adviceCache.clear(); } //empty the advice cache map
+function clearAdviceCache() { adviceCache.clear(); } //empty cache via LRU method
 
-let purgeIterator = null; //iterator to scan cache incrementally
-
-function purgeExpiredAdvice(batch = 50) { //drop expired advice entries in pieces
-        if (CACHE_TTL_SECONDS === 0 || adviceCache.size === 0) { return; } //skip when ttl disabled or cache empty
-        if (!purgeIterator) { purgeIterator = adviceCache.entries(); } //(init iterator on first call)
-        const now = Date.now(); //current time for comparisons
-        for (let i = 0; i < batch; i++) { //scan limited entries per run
-                const next = purgeIterator.next(); //fetch next cache item
-                if (next.done) { purgeIterator = null; break; } //(reset when traversal complete)
-                const [key, val] = next.value; //item pair from map
-                if (now - val.ts > CACHE_TTL_SECONDS * 1000) { adviceCache.delete(key); } //delete when older than ttl
-        }
-} //remove up to batch entries past TTL per call
+function purgeExpiredAdvice() { //trigger lru-cache cleanup cycle
+        if (CACHE_TTL_SECONDS === 0 || ADVICE_CACHE_LIMIT === 0) { return; } //skip when ttl or cache disabled
+        adviceCache.purgeStale(); //remove expired entries using library
+} //lru-cache handles its own batch logic
 
 function getQueueLength() { return limit.pendingCount; } //expose queue length
 
@@ -158,19 +150,13 @@ async function analyzeError(error, context) {
                         error message: "${error.message}",
                         with context: "${context}"`);
 
-        if (ADVICE_CACHE_LIMIT !== 0 && !error.qerrorsKey) { //skip hashing when cache disabled then generate key
-                error.qerrorsKey = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //hash message and stack for caching
+        if (ADVICE_CACHE_LIMIT !== 0 && !error.qerrorsKey) { //generate hash key when caching
+                error.qerrorsKey = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //create cache key from message and stack
         }
 
-        if (ADVICE_CACHE_LIMIT !== 0 && adviceCache.has(error.qerrorsKey)) { //skip api call when caching enabled and hit
-                const cached = adviceCache.get(error.qerrorsKey); //retrieve cached entry object
-                if (CACHE_TTL_SECONDS === 0 || Date.now() - cached.ts < CACHE_TTL_SECONDS * 1000) { //validate ttl
-                        adviceCache.delete(error.qerrorsKey); //move to most recent for LRU
-                        adviceCache.set(error.qerrorsKey, cached); //reinsert to maintain order
-                        verboseLog(`cache hit for ${error.uniqueErrorName}`); //log cache usage
-                        return cached.advice; //return cached advice value
-                }
-                adviceCache.delete(error.qerrorsKey); //remove expired entry
+        if (ADVICE_CACHE_LIMIT !== 0) { //lookup cached advice when enabled
+                const cached = adviceCache.get(error.qerrorsKey); //fetch entry from lru-cache
+                if (cached) { verboseLog(`cache hit for ${error.uniqueErrorName}`); return cached; } //return when present and valid
         }
 
         // Graceful degradation when API token is not available
@@ -241,18 +227,12 @@ async function analyzeError(error, context) {
 		// Handle structured response with data property
                 if (advice.data) {
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
-                        if (ADVICE_CACHE_LIMIT !== 0) { //only cache when limit not zero
-                                adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //store advice with timestamp
-                                if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //evict oldest when limit exceeded
-                        }
+                        if (ADVICE_CACHE_LIMIT !== 0) { adviceCache.set(error.qerrorsKey, advice); } //cache structured advice
                         return advice;
                 } else if (advice) {
                         // Handle direct advice object
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
-                        if (ADVICE_CACHE_LIMIT !== 0) { //cache only if enabled
-                                adviceCache.set(error.qerrorsKey, { advice, ts: Date.now() }); //cache direct advice with timestamp
-                                if (adviceCache.size > ADVICE_CACHE_LIMIT) { adviceCache.delete(adviceCache.keys().next().value); } //keep cache size
-                        }
+                        if (ADVICE_CACHE_LIMIT !== 0) { adviceCache.set(error.qerrorsKey, advice); } //cache direct advice
                         return advice;
                 }
 	} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.9.0",
         "p-limit": "^4.0.0",
         "qtests": "^1.0.2",
-        "winston": "^3.13.0"
+        "winston": "^3.13.0",
+        "lru-cache": "^10.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "axios": "^1.9.0",
     "p-limit": "^4.0.0",
     "qtests": "^1.0.2",
-    "winston": "^3.13.0"
+    "winston": "^3.13.0",
+    "lru-cache": "^10.0.0"
   },
   "directories": {
     "lib": "lib"

--- a/stubs/lru-cache.js
+++ b/stubs/lru-cache.js
@@ -1,0 +1,28 @@
+class LRU {
+  constructor(opts = {}) {
+    this.max = opts.max ?? Infinity; //limit of entries
+    this.ttl = opts.ttl ?? 0; //time to live in ms
+    this.store = new Map(); //internal storage Map
+  }
+  get size() { return this.store.size; }
+  get(key) { //retrieve value or undefined
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (this.ttl && Date.now() - entry.ts > this.ttl) { this.store.delete(key); return undefined; }
+    this.store.delete(key); this.store.set(key, entry); //move to newest
+    return entry.val;
+  }
+  set(key, val) { //insert value and enforce size limit
+    this.store.delete(key);
+    this.store.set(key, { val, ts: Date.now() });
+    if (this.store.size > this.max) { const first = this.store.keys().next().value; this.store.delete(first); }
+  }
+  has(key) { return this.get(key) !== undefined; }
+  delete(key) { return this.store.delete(key); }
+  clear() { this.store.clear(); }
+  purgeStale() { //remove expired entries
+    if (!this.ttl) return; const now = Date.now();
+    for (const [k, e] of this.store) { if (now - e.ts > this.ttl) this.store.delete(k); }
+  }
+}
+module.exports = LRU;


### PR DESCRIPTION
## Summary
- replace manual advice cache Map with `lru-cache`
- clean up purge logic
- add a stub for `lru-cache` in tests
- track new `lru-cache` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844acc0c6f88322801d1edaa5884d66