### PR TITLE
Refactor logger init

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,19 +24,11 @@ const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
-function initLogDirSync() { //ensure log directory synchronously
-        try { fs.mkdirSync(logDir, { recursive: true }); } //(make directory blocking)
-        catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(log and disable files)
-}
 async function initLogDir() { //prepare log directory asynchronously
-        try { await fs.promises.mkdir(logDir, { recursive: true }); } //(create dir async for tests)
-        catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(record failure)
+        try { await fs.promises.mkdir(logDir, { recursive: true }); } //(create dir async once)
+        catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(record failure and disable files)
 }
-initLogDirSync(); //create directory before logger
-const initPromise = initLogDir(); //continue async init for error reporting
-
-try { fs.mkdirSync(logDir, { recursive: true }); } //(ensure directory before logger init)
-catch (err) { console.error(`Failed sync check of log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(fallback to console only)
+const initPromise = initLogDir(); //start async directory creation before logger
 
 
 


### PR DESCRIPTION
## Summary
- streamline log directory setup in `lib/logger.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844acca84048322b9c5ba73267ecb91