### PR TITLE
Add log max days warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
-* `QERRORS_LOG_MAX_DAYS` &ndash; days to retain daily logs (default `0`).
+ * `QERRORS_LOG_MAX_DAYS` &ndash; days to retain daily logs (default `0`). Setting `0` with file logging enabled triggers a startup warning because logs may grow without bound. //(document startup warning behavior)
 * `QERRORS_VERBOSE` &ndash; enable console logging (`true` by default). Set `QERRORS_VERBOSE=false` for production deployments to keep logs from flooding the console and rely on file output instead.
 * `QERRORS_LOG_DIR` &ndash; directory for logger output (default `logs`).
 * `QERRORS_DISABLE_FILE_LOGS` &ndash; disable file transports when set.
@@ -67,7 +67,7 @@ Additional options control the logger's file rotation:
 
 * `QERRORS_LOG_MAXSIZE` - max log file size in bytes before rotation (default `1048576`)
 * `QERRORS_LOG_MAXFILES` - number of rotated files to keep (default `5`)
-* `QERRORS_LOG_MAX_DAYS` - number of days to keep daily logs (default `0`)
+ * `QERRORS_LOG_MAX_DAYS` - number of days to keep daily logs (default `0`). Setting `0` with file logs active emits a startup warning that log files may grow without bound. //(note about startup warning)
 * `QERRORS_LOG_DIR` - path for log files (default `logs`)
 * `QERRORS_DISABLE_FILE_LOGS` - omit file logs when set
 * `QERRORS_SERVICE_NAME` - service name added to logger metadata (default `qerrors`)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -104,8 +104,9 @@ const logger = createLogger({
                }
                if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //console only when verbose
                return arr; //provide configured transports
-       })()
+        })()
 });
+if (maxDays === 0 && !disableFileLogs) { logger.warn('QERRORS_LOG_MAX_DAYS is 0; log files may grow without bound'); } //(warn about unlimited log retention)
 
 function logStart(name, data) { logger.info(`${name} start ${JSON.stringify(data)}`); } //log start info //(use info to match stub)
 function logReturn(name, data) { logger.info(`${name} return ${JSON.stringify(data)}`); } //log result info //(use info to match stub)

--- a/test/serviceName.test.js
+++ b/test/serviceName.test.js
@@ -13,7 +13,7 @@ test('logger uses QERRORS_SERVICE_NAME env var', () => {
   const orig = process.env.QERRORS_SERVICE_NAME; //save original value
   process.env.QERRORS_SERVICE_NAME = 'svc'; //set custom name
   let captured; //will capture config passed to createLogger
-  const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta }; });
+  const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta, warn() {}, info() {}, error() {} }; }); //include warn for startup check
   const logger = reloadLogger(); //reload module
   try {
     assert.equal(captured.defaultMeta.service, 'svc'); //verify custom service
@@ -29,7 +29,7 @@ test('logger defaults QERRORS_SERVICE_NAME when unset', () => {
   const orig = process.env.QERRORS_SERVICE_NAME; //store original
   delete process.env.QERRORS_SERVICE_NAME; //unset for default test
   let captured; //capture config
-  const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta }; });
+  const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta, warn() {}, info() {}, error() {} }; }); //include warn for startup check
   const logger = reloadLogger(); //reload module
   try {
     assert.equal(captured.defaultMeta.service, 'qerrors'); //uses default

--- a/test/verbose.test.js
+++ b/test/verbose.test.js
@@ -13,7 +13,7 @@ test('logger adds Console transport when verbose true', () => {
   const orig = process.env.QERRORS_VERBOSE; //save original env
   process.env.QERRORS_VERBOSE = 'true'; //enable console logging
   let captured; //will hold config passed in
-  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports }; }); //capture transports
+  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports, warn() {}, info() {}, error() {} }; }); //capture transports with warn for startup check
   const logger = reloadLogger(); //load module under new env
   try {
     const hasConsole = captured.transports.some(t => t instanceof winston.transports.Console); //check captured transports
@@ -30,7 +30,7 @@ test('logger excludes Console transport when verbose false', () => {
   const orig = process.env.QERRORS_VERBOSE; //save env
   process.env.QERRORS_VERBOSE = 'false'; //disable console
   let captured; //hold config
-  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports }; }); //capture transports
+  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports, warn() {}, info() {}, error() {} }; }); //capture transports with warn for startup check
   const logger = reloadLogger(); //reload module
   try {
     const hasConsole = captured.transports.some(t => t instanceof winston.transports.Console); //detect console


### PR DESCRIPTION
## Summary
- warn at startup when daily rotation days are 0 and file logging is enabled
- document the warning behaviour in README
- update tests to stub `warn` for logger initialization

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844acd04b348322a09b5dc4a85c1717