### PR TITLE
Synchronous log dir creation

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,11 +24,11 @@ const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
-async function initLogDir() { //prepare log directory asynchronously
-        try { await fs.promises.mkdir(logDir, { recursive: true }); } //(create dir async once)
+function initLogDir() { //prepare log directory synchronously
+        try { fs.mkdirSync(logDir, { recursive: true }); } //create dir sync once
         catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(record failure and disable files)
 }
-const initPromise = initLogDir(); //start async directory creation before logger
+initLogDir(); //create directory synchronously before logger
 
 
 
@@ -108,4 +108,3 @@ function logReturn(name, data) { logger.info(`${name} return ${JSON.stringify(da
 module.exports = logger;
 module.exports.logStart = logStart; //export start logger //(make available to env utils)
 module.exports.logReturn = logReturn; //export return logger //(make available to env utils)
-module.exports.initPromise = initPromise; //export initialization completion promise //(enable awaiting)


### PR DESCRIPTION
## Summary
- create log directory synchronously in logger
- drop `initPromise` export
- update tests for sync mkdir behavior
- verify file transports when mkdirSync succeeds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844b3e6929483229525e9c32fc97537