### PR TITLE
Async logger initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npm install qerrors
 const {qerrors} = require('qerrors');
 // OR import both qerrors and logger: //(changed qErrors to qerrors for casing consistency)
 const { qerrors, logger } = require('qerrors');
+const log = await logger; //await logger initialization before use
 
 // Example of using qerrors as Express middleware:
 app.use((err, req, res, next) => {
@@ -128,9 +129,9 @@ function doFunction(param1, param2) {
 }
 
 // Using the Winston logger directly:
-logger.info('Application started');
-logger.warn('Something might be wrong');
-logger.error('An error occurred', { errorDetails: error });
+log.info('Application started');
+log.warn('Something might be wrong');
+log.error('An error occurred', { errorDetails: error });
 ```
 
 ## Testing

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,22 +24,21 @@ const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
-function initLogDir() { //prepare log directory synchronously
-        try { fs.mkdirSync(logDir, { recursive: true }); } //create dir sync once
+async function initLogDir() { //prepare log directory asynchronously
+        try { await fs.promises.mkdir(logDir, { recursive: true }); } //create dir async once
         catch (err) { console.error(`Failed to create log directory ${logDir}: ${err.message}`); disableFileLogs = true; } //(record failure and disable files)
 }
-initLogDir(); //create directory synchronously before logger
 
 
 
 /**
  * Winston logger instance with multi-format, multi-transport configuration
- * 
+ *
  * Transport strategy:
  * 1. Error-only file for focused error analysis and alerting
  * 2. Combined file for comprehensive audit trail and debugging
  * 3. Console for immediate development feedback and debugging
- * 
+ *
  * Format strategy combines multiple Winston formatters:
  * - Timestamp: Consistent chronological ordering across environments
  * - Errors: Proper stack trace handling for Error objects
@@ -47,7 +46,9 @@ initLogDir(); //create directory synchronously before logger
  * - JSON: Structured data for log analysis tools
  * - Printf: Human-readable final format for console output
  */
-const logger = createLogger({
+async function buildLogger() { //create logger after dir ready
+        await initLogDir(); //ensure directory exists before transports
+        const log = createLogger({
 	// Info level captures errors, warnings, and informational messages
 	// This provides comprehensive logging without debug noise in production
 	level: 'info',
@@ -97,14 +98,16 @@ const logger = createLogger({
                if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //console only when verbose
                return arr; //provide configured transports
         })()
-});
-if (maxDays === 0 && !disableFileLogs) { logger.warn('QERRORS_LOG_MAX_DAYS is 0; log files may grow without bound'); } //(warn about unlimited log retention)
+        });
+        if (maxDays === 0 && !disableFileLogs) { log.warn('QERRORS_LOG_MAX_DAYS is 0; log files may grow without bound'); } //(warn about unlimited log retention)
+        return log; //provide created logger
+}
 
-function logStart(name, data) { logger.info(`${name} start ${JSON.stringify(data)}`); } //log start info //(use info to match stub)
-function logReturn(name, data) { logger.info(`${name} return ${JSON.stringify(data)}`); } //log result info //(use info to match stub)
+const logger = buildLogger(); //async logger promise
 
-// Export configured logger instance
-// This provides a consistent logging interface across the entire qerrors module
-module.exports = logger;
+async function logStart(name, data) { const log = await logger; log.info(`${name} start ${JSON.stringify(data)}`); } //log start info //(use promise to invoke logger)
+async function logReturn(name, data) { const log = await logger; log.info(`${name} return ${JSON.stringify(data)}`); } //log result info //(use promise to invoke logger)
+
+module.exports = logger; //export promise for initialization
 module.exports.logStart = logStart; //export start logger //(make available to env utils)
 module.exports.logReturn = logReturn; //export return logger //(make available to env utils)

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -16,7 +16,7 @@
 'use strict'; //(enable strict mode for improved error detection)
 const config = require('./config'); //load default environment variables and helpers
 
-const logger = require('./logger'); //centralized winston logger configuration
+const logger = require('./logger'); //centralized winston logger configuration promise
 const axios = require('axios'); //HTTP client used for OpenAI API calls
 const http = require('http'); //node http for agent keep alive
 const https = require('https'); //node https for agent keep alive
@@ -36,7 +36,7 @@ const rawQueue = config.getInt('QERRORS_QUEUE_LIMIT'); //(raw queue limit from e
 const SAFE_THRESHOLD = config.getInt('QERRORS_SAFE_THRESHOLD', 1000); //limit considered safe for concurrency and queue //(configurable)
 const CONCURRENCY_LIMIT = Math.min(rawConc, SAFE_THRESHOLD); //(clamp concurrency to safe threshold)
 const QUEUE_LIMIT = Math.min(rawQueue, SAFE_THRESHOLD); //(clamp queue limit to safe threshold)
-if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`); } //(warn when original limits exceed threshold)
+if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.then(l => l.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`)); } //(warn when original limits exceed threshold)
 
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
@@ -77,7 +77,7 @@ function stopAdviceCleanup() { //(stop periodic purge when needed)
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         startAdviceCleanup(); //(ensure cleanup interval scheduled once)
         const total = limit.pendingCount + limit.activeCount; //sum queued and active analyses
-        if (total >= QUEUE_LIMIT) { queueRejectCount++; logger.warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } //(reject when queue limit reached)
+        if (total >= QUEUE_LIMIT) { queueRejectCount++; (await logger).warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } //(reject when queue limit reached)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 
 }
@@ -332,7 +332,7 @@ async function qerrors(error, context, req, res, next) {
 	
 	// Log error through winston logger for persistent storage and processing
 	// Uses structured logging format compatible with log aggregation systems
-	logger.error(errorLog);
+        (await logger).error(errorLog);
 	
 
 	
@@ -386,7 +386,7 @@ async function qerrors(error, context, req, res, next) {
 
         Promise.resolve() //start async analysis without blocking response
                 .then(() => scheduleAnalysis(error, context)) //invoke queued analysis after sending response
-                .catch((analysisErr) => logger.error(analysisErr)); //log any scheduleAnalysis failures
+                .catch(async (analysisErr) => (await logger).error(analysisErr)); //log any scheduleAnalysis failures
 
         verboseLog(`qerrors ran`); //log completion after scheduling analysis
 }

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -13,7 +13,7 @@ test('scheduleAnalysis rejects when queue exceeds limit', async () => {
   process.env.QERRORS_CONCURRENCY = '1'; //one concurrent analysis
   process.env.QERRORS_QUEUE_LIMIT = '1'; //allow single queued item
   const qerrors = reloadQerrors(); //reload with env vars
-  const logger = require('../lib/logger'); //logger instance
+  const logger = await require('../lib/logger'); //logger instance
   let logged; //capture logged error
   const restoreLog = qtests.stubMethod(logger, 'error', (e) => { logged = e; });
   const restoreAnalyze = qtests.stubMethod(qerrors, 'analyzeError', async () => {
@@ -41,7 +41,7 @@ test('queue reject count increments when queue exceeds limit', async () => {
   process.env.QERRORS_CONCURRENCY = '1'; //force single concurrency
   process.env.QERRORS_QUEUE_LIMIT = '1'; //allow one queued before rejection
   const qerrors = reloadQerrors(); //reload to apply env
-  const logger = require('../lib/logger'); //logger instance
+  const logger = await require('../lib/logger'); //logger instance
   const restoreWarn = qtests.stubMethod(logger, 'warn', () => {}); //silence warn
   const restoreError = qtests.stubMethod(logger, 'error', () => {}); //silence err
   const restoreAnalyze = qtests.stubMethod(qerrors, 'analyzeError', async () => {
@@ -70,7 +70,7 @@ test('getQueueLength reflects queued analyses', async () => {
   process.env.QERRORS_QUEUE_LIMIT = '2'; //allow one queued item
   process.env.OPENAI_TOKEN = 'tkn'; //enable analyzeError path
   const qerrors = reloadQerrors(); //reload to apply env
-  const logger = require('../lib/logger'); //logger instance
+  const logger = await require('../lib/logger'); //logger instance
   const restoreWarn = qtests.stubMethod(logger, 'warn', () => {}); //silence warn
   const restoreError = qtests.stubMethod(logger, 'error', () => {}); //silence err
   const capture = {}; //track axios args
@@ -118,7 +118,7 @@ test('queue never exceeds limit under high concurrency', async () => {
   process.env.QERRORS_CONCURRENCY = '3'; //allow more active analyses
   process.env.QERRORS_QUEUE_LIMIT = '1'; //only one queued task
   const qerrors = reloadQerrors(); //reload config vars
-  const logger = require('../lib/logger'); //logger instance
+  const logger = await require('../lib/logger'); //logger instance
   const restoreWarn = qtests.stubMethod(logger, 'warn', () => {}); //silence warn
   const restoreError = qtests.stubMethod(logger, 'error', () => {}); //silence error
   const restoreAnalyze = qtests.stubMethod(qerrors, 'analyzeError', async () => new Promise(r => setTimeout(r, 20))); //simulate work

--- a/test/serviceName.test.js
+++ b/test/serviceName.test.js
@@ -9,15 +9,15 @@ function reloadLogger() { //reload logger with current env
   return require('../lib/logger');
 }
 
-test('logger uses QERRORS_SERVICE_NAME env var', () => {
+test('logger uses QERRORS_SERVICE_NAME env var', async () => {
   const orig = process.env.QERRORS_SERVICE_NAME; //save original value
   process.env.QERRORS_SERVICE_NAME = 'svc'; //set custom name
   let captured; //will capture config passed to createLogger
   const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta, warn() {}, info() {}, error() {} }; }); //include warn for startup check
-  const logger = reloadLogger(); //reload module
+  const logger = await reloadLogger(); //reload module and await
   try {
     assert.equal(captured.defaultMeta.service, 'svc'); //verify custom service
-    assert.equal(logger.defaultMeta.service, 'svc'); //logger carries meta
+    assert.equal((await logger).defaultMeta.service, 'svc'); //logger carries meta
   } finally {
     restore(); //restore stubbed method
     if (orig === undefined) { delete process.env.QERRORS_SERVICE_NAME; } else { process.env.QERRORS_SERVICE_NAME = orig; }
@@ -25,15 +25,15 @@ test('logger uses QERRORS_SERVICE_NAME env var', () => {
   }
 });
 
-test('logger defaults QERRORS_SERVICE_NAME when unset', () => {
+test('logger defaults QERRORS_SERVICE_NAME when unset', async () => {
   const orig = process.env.QERRORS_SERVICE_NAME; //store original
   delete process.env.QERRORS_SERVICE_NAME; //unset for default test
   let captured; //capture config
   const restore = qtests.stubMethod(winston, 'createLogger', (cfg) => { captured = cfg; return { defaultMeta: cfg.defaultMeta, warn() {}, info() {}, error() {} }; }); //include warn for startup check
-  const logger = reloadLogger(); //reload module
+  const logger = await reloadLogger(); //reload module and await
   try {
     assert.equal(captured.defaultMeta.service, 'qerrors'); //uses default
-    assert.equal(logger.defaultMeta.service, 'qerrors'); //logger meta default
+    assert.equal((await logger).defaultMeta.service, 'qerrors'); //logger meta default
   } finally {
     restore(); //restore stub
     if (orig === undefined) { delete process.env.QERRORS_SERVICE_NAME; } else { process.env.QERRORS_SERVICE_NAME = orig; }

--- a/test/verbose.test.js
+++ b/test/verbose.test.js
@@ -9,12 +9,13 @@ function reloadLogger() { //reload logger for each test
   return require('../lib/logger');
 }
 
-test('logger adds Console transport when verbose true', () => {
+test('logger adds Console transport when verbose true', async () => {
   const orig = process.env.QERRORS_VERBOSE; //save original env
   process.env.QERRORS_VERBOSE = 'true'; //enable console logging
   let captured; //will hold config passed in
   const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports, warn() {}, info() {}, error() {} }; }); //capture transports with warn for startup check
-  const logger = reloadLogger(); //load module under new env
+  const logger = await reloadLogger(); //load module under new env
+  await logger;
   try {
     const hasConsole = captured.transports.some(t => t instanceof winston.transports.Console); //check captured transports
     assert.equal(hasConsole, true); //expect console present
@@ -26,12 +27,13 @@ test('logger adds Console transport when verbose true', () => {
   }
 });
 
-test('logger excludes Console transport when verbose false', () => {
+test('logger excludes Console transport when verbose false', async () => {
   const orig = process.env.QERRORS_VERBOSE; //save env
   process.env.QERRORS_VERBOSE = 'false'; //disable console
   let captured; //hold config
   const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { transports: cfg.transports, warn() {}, info() {}, error() {} }; }); //capture transports with warn for startup check
-  const logger = reloadLogger(); //reload module
+  const logger = await reloadLogger(); //reload module
+  await logger;
   try {
     const hasConsole = captured.transports.some(t => t instanceof winston.transports.Console); //detect console
     assert.equal(hasConsole, false); //expect none


### PR DESCRIPTION
## Summary
- refactor logger initialization to use `fs.promises.mkdir`
- adapt qerrors to await the logger promise
- update README usage snippet for new async logger
- fix tests to handle logger initialization promise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844e9321668832291f04f5a64d3d504