### PR TITLE
Clamp advice cache limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `OPENAI_TOKEN` &ndash; your OpenAI API key.
 * `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic, values over `1000` are clamped). //(document clamp)
 
-* `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching).
+* `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching, values over `1000` are clamped).
 * `QERRORS_CACHE_TTL` &ndash; seconds before cached advice expires (default `86400`).
 * `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load, values over `1000` are clamped). //(document queue clamp)
 * `QERRORS_SAFE_THRESHOLD` &ndash; maximum allowed value for `QERRORS_CONCURRENCY` and `QERRORS_QUEUE_LIMIT` before clamping occurs (default `1000`). //(document configurable safe clamp)
@@ -63,7 +63,7 @@ The retry behaviour can be tuned with QERRORS_RETRY_ATTEMPTS, QERRORS_RETRY_BASE
 When the API responds with 429 or 503 qerrors uses the `Retry-After` header to wait before retrying; if the header is missing the computed delay is doubled. //(document rate limit behaviour)
 
 You will need to set OPENAI_TOKEN in your environment, get your key at [OpenAI](https://openai.com).
-You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50). Use `QERRORS_CACHE_TTL` to control how long each entry stays valid in seconds (default is 86400).
+You can optionally set `QERRORS_CACHE_LIMIT` to adjust how many advice entries are cached; set `0` to disable caching (default is 50, values over `1000` are clamped). Use `QERRORS_CACHE_TTL` to control how long each entry stays valid in seconds (default is 86400).
 
 Additional options control the logger's file rotation:
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -40,7 +40,8 @@ if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.warn(`High q
 
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
-const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : parsedLimit; //0 disables cache otherwise use parsed limit
+const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : Math.min(parsedLimit, SAFE_THRESHOLD); //clamp to safe threshold when >0
+if (parsedLimit > SAFE_THRESHOLD) { logger.warn(`cache limit clamped ${parsedLimit}`); } //warn on clamp similar to other limits
 const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
 const adviceCache = new LRU({ max: ADVICE_CACHE_LIMIT || 0, ttl: CACHE_TTL_SECONDS * 1000 }); //lru-cache instance using env limits
@@ -409,4 +410,6 @@ module.exports.startAdviceCleanup = startAdviceCleanup; //export cleanup schedul
 module.exports.stopAdviceCleanup = stopAdviceCleanup; //export cleanup canceller
 
 module.exports.getQueueLength = getQueueLength; //export queue length
+function getAdviceCacheLimit() { return ADVICE_CACHE_LIMIT; } //expose clamped cache limit for tests
+module.exports.getAdviceCacheLimit = getAdviceCacheLimit; //export clamp accessor
 


### PR DESCRIPTION
## Summary
- clamp `QERRORS_CACHE_LIMIT` to the safe threshold to avoid memory bloat
- log a warning when cache limit is clamped
- expose `getAdviceCacheLimit` for tests
- test cache limit clamping
- document cache limit clamping in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844e942295883228adf5b886329e871