### PR TITLE
Allow custom safe threshold

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -33,7 +33,7 @@ function verboseLog(msg) { //conditional console output helper
 const rawConc = config.getInt('QERRORS_CONCURRENCY'); //(raw concurrency from env)
 const rawQueue = config.getInt('QERRORS_QUEUE_LIMIT'); //(raw queue limit from env)
 
-const SAFE_THRESHOLD = config.getInt('QERRORS_SAFE_THRESHOLD', 1000); //limit considered safe for concurrency and queue //(configurable)
+const SAFE_THRESHOLD = config.getInt('QERRORS_SAFE_THRESHOLD'); //limit considered safe for concurrency and queue without enforced minimum //(configurable)
 const CONCURRENCY_LIMIT = Math.min(rawConc, SAFE_THRESHOLD); //(clamp concurrency to safe threshold)
 const QUEUE_LIMIT = Math.min(rawQueue, SAFE_THRESHOLD); //(clamp queue limit to safe threshold)
 if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.then(l => l.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`)); } //(warn when original limits exceed threshold)


### PR DESCRIPTION
## Summary
- fetch `QERRORS_SAFE_THRESHOLD` without enforcing minimum

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68451ad039808322bba8368afe08cd48