### PR TITLE
Clamp max sockets

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -38,6 +38,10 @@ const CONCURRENCY_LIMIT = Math.min(rawConc, SAFE_THRESHOLD); //(clamp concurrenc
 const QUEUE_LIMIT = Math.min(rawQueue, SAFE_THRESHOLD); //(clamp queue limit to safe threshold)
 if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.then(l => l.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`)); } //(warn when original limits exceed threshold)
 
+const rawSockets = config.getInt('QERRORS_MAX_SOCKETS'); //raw sockets from env
+const MAX_SOCKETS = Math.min(rawSockets, SAFE_THRESHOLD); //clamp sockets to safe threshold
+if (rawSockets > SAFE_THRESHOLD) { logger.then(l => l.warn(`max sockets clamped ${rawSockets}`)); } //warn on clamp when limit exceeded
+
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : Math.min(parsedLimit, SAFE_THRESHOLD); //clamp to safe threshold when >0
@@ -49,8 +53,8 @@ const adviceCache = new LRU({ max: ADVICE_CACHE_LIMIT || 0, ttl: CACHE_TTL_SECON
 let warnedMissingToken = false; //track if missing token message already logged
 
 const axiosInstance = axios.create({ //axios instance with keep alive agents
-        httpAgent: new http.Agent({ keepAlive: true, maxSockets: config.getInt('QERRORS_MAX_SOCKETS') }), //reuse http connections with limit
-        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: config.getInt('QERRORS_MAX_SOCKETS') }), //reuse https connections with limit
+        httpAgent: new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS }), //reuse http connections with clamped limit
+        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS }), //reuse https connections with clamped limit
         timeout: config.getInt('QERRORS_TIMEOUT') //abort request after timeout
 });
 


### PR DESCRIPTION
## Summary
- clamp QERRORS_MAX_SOCKETS using SAFE_THRESHOLD
- warn when sockets env exceeds the safe limit
- test clamping behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68451ad849a483229e1e5a6b15771b23