### PR TITLE
Fix unlimited logs when QERRORS_LOG_MAX_DAYS=0

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -91,8 +91,9 @@ async function buildLogger() { //create logger after dir ready
                                 arr.push(new DailyRotateFile({ filename: path.join(logDir, 'error-%DATE%.log'), level: 'error', datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize }));
                                 arr.push(new DailyRotateFile({ filename: path.join(logDir, 'combined-%DATE%.log'), datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize }));
                         } else {
-                                arr.push(new transports.File({ filename: path.join(logDir, 'error.log'), level: 'error', ...rotationOpts }));
-                                arr.push(new transports.File({ filename: path.join(logDir, 'combined.log'), ...rotationOpts }));
+                                const fileCap = rotationOpts.maxFiles > 0 ? rotationOpts.maxFiles : 30; //fallback cap when days zero
+                                arr.push(new transports.File({ filename: path.join(logDir, 'error.log'), level: 'error', ...rotationOpts, maxFiles: fileCap })); //limit rotated error files
+                                arr.push(new transports.File({ filename: path.join(logDir, 'combined.log'), ...rotationOpts, maxFiles: fileCap })); //limit rotated combined files
                         }
                }
                if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //console only when verbose


### PR DESCRIPTION
## Summary
- keep startup warning for unlimited day retention
- clamp file log rotation count when `QERRORS_LOG_MAX_DAYS` is `0`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845770006308322a70579559ee15ccb