### PR TITLE
Improve queue using denque

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ if not set the default limit is 5; raise this for high traffic. //explain fallba
 
 Use QERRORS_QUEUE_LIMIT to cap how many analyses can wait in line before rejection; //(explain queue limit)
 if not set the default limit is 100; increase when expecting heavy load. //(explain queue default)
+The pending queue uses a double ended queue from the denque package for efficient O(1) dequeues. //(document deque)
 
 Whenever the queue rejects an analysis the module increments an internal counter. //(document reject counter)
 Check it with `qerrors.getQueueRejectCount()`. //(usage note)

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -22,9 +22,10 @@ const http = require('http'); //node http for agent keep alive
 const https = require('https'); //node https for agent keep alive
 const crypto = require('crypto'); //node crypto for hashing cache keys
 const { randomUUID } = require('crypto'); //import UUID generator for unique names
+const Denque = require('denque'); //double ended queue for O(1) dequeue
 function createLimiter(max) { //(local concurrency limiter to avoid p-limit)
         let active = 0; //count currently running tasks
-        const queue = []; //queued functions waiting for a slot
+        const queue = new Denque(); //queued functions waiting for a slot with O(1) shift
         const next = () => { //execute next when possible
                 if (active >= max || queue.length === 0) return; //respect limit
                 const { fn, resolve, reject } = queue.shift(); //get next job

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "axios": "^1.9.0",
     "lru-cache": "^10.0.0",
+    "denque": "^2.1.0",
     "qtests": "^1.0.4",
     "winston": "^3.13.0",
     "winston-daily-rotate-file": "^5.0.0"

--- a/stubs/denque.js
+++ b/stubs/denque.js
@@ -1,0 +1,7 @@
+class Denque {
+  constructor(){ this.items = []; }
+  push(val){ this.items.push(val); } //add item to end
+  shift(){ return this.items.shift(); } //remove item from front
+  get length(){ return this.items.length; } //queue size
+}
+module.exports = Denque; //export stub class


### PR DESCRIPTION
## Summary
- add denque dependency
- use Denque in limiter queue for O(1) dequeues
- document Denque usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684576ef0b848322b34e9a37088fc0a9