### PR TITLE
Add maxFreeSockets config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_RETRY_MAX_MS` &ndash; cap on retry backoff in ms (default `2000`).
 * `QERRORS_TIMEOUT` &ndash; axios request timeout in ms (default `10000`).
 * `QERRORS_MAX_SOCKETS` &ndash; maximum sockets per agent (default `50`, increase for high traffic).
+* `QERRORS_MAX_FREE_SOCKETS` &ndash; maximum idle sockets per agent (default `256`).
 
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
@@ -32,7 +33,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_DISABLE_FILE_LOGS` &ndash; disable file transports when set.
 * `QERRORS_SERVICE_NAME` &ndash; service name added to logger metadata (default `qerrors`). //(document service variable)
 
-For high traffic scenarios raise `QERRORS_CONCURRENCY`, `QERRORS_QUEUE_LIMIT`, and `QERRORS_MAX_SOCKETS`. Set `QERRORS_VERBOSE=false` in production to reduce console overhead.
+For high traffic scenarios raise `QERRORS_CONCURRENCY`, `QERRORS_QUEUE_LIMIT`, `QERRORS_MAX_SOCKETS`, and `QERRORS_MAX_FREE_SOCKETS`. Set `QERRORS_VERBOSE=false` in production to reduce console overhead.
 
 
 Set QERRORS_CONCURRENCY to adjust how many analyses run simultaneously; //new variable controlling concurrency
@@ -54,6 +55,8 @@ Use `qerrors.getQueueLength()` to monitor how many analyses are waiting. //(ment
 
 QERRORS_MAX_SOCKETS lets you limit how many sockets the http agents open; //document new env var usage
 if not set the default is 50; raise this to handle high traffic. //state default behaviour
+QERRORS_MAX_FREE_SOCKETS caps idle sockets the agents keep for reuse; //explain idle setting
+if not set the default is 256 which matches Node's agent default. //state default value
 
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ const defaults = { //default environment variable values
   QERRORS_RETRY_MAX_MS: '2000', //cap wait time for exponential backoff //(new env default)
   QERRORS_TIMEOUT: '10000', //axios request timeout in ms
   QERRORS_MAX_SOCKETS: '50', //max sockets per http/https agent
+  QERRORS_MAX_FREE_SOCKETS: '256', //max idle sockets per agent //(new env default)
 
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -68,6 +68,10 @@ const rawSockets = config.getInt('QERRORS_MAX_SOCKETS'); //raw sockets from env
 const MAX_SOCKETS = Math.min(rawSockets, SAFE_THRESHOLD); //clamp sockets to safe threshold
 if (rawSockets > SAFE_THRESHOLD) { logger.then(l => l.warn(`max sockets clamped ${rawSockets}`)); } //warn on clamp when limit exceeded
 
+const rawFreeSockets = config.getInt('QERRORS_MAX_FREE_SOCKETS'); //raw free socket count from env //(new env)
+const MAX_FREE_SOCKETS = Math.min(rawFreeSockets, SAFE_THRESHOLD); //clamp free sockets to safe threshold //(new const)
+if (rawFreeSockets > SAFE_THRESHOLD) { logger.then(l => l.warn(`max free sockets clamped ${rawFreeSockets}`)); } //warn when clamped //(new warn)
+
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : Math.min(parsedLimit, SAFE_THRESHOLD); //clamp to safe threshold when >0
@@ -79,8 +83,8 @@ const adviceCache = new LRUCache({ max: ADVICE_CACHE_LIMIT || 0, ttl: CACHE_TTL_
 let warnedMissingToken = false; //track if missing token message already logged
 
 const axiosInstance = axios.create({ //axios instance with keep alive agents
-        httpAgent: new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS }), //reuse http connections with clamped limit
-        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS }), //reuse https connections with clamped limit
+        httpAgent: new http.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS, maxFreeSockets: MAX_FREE_SOCKETS }), //reuse http connections with max free limit //(updated agent)
+        httpsAgent: new https.Agent({ keepAlive: true, maxSockets: MAX_SOCKETS, maxFreeSockets: MAX_FREE_SOCKETS }), //reuse https connections with max free limit //(updated agent)
         timeout: config.getInt('QERRORS_TIMEOUT') //abort request after timeout
 });
 

--- a/test/maxFreeSockets.test.js
+++ b/test/maxFreeSockets.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //strict assertions
+
+function reloadQerrors() { //reload module to apply env vars
+  delete require.cache[require.resolve('../lib/qerrors')]; //clear qerrors cache
+  delete require.cache[require.resolve('../lib/config')]; //clear config cache
+  return require('../lib/qerrors'); //return fresh module
+}
+
+test('axiosInstance honors QERRORS_MAX_FREE_SOCKETS', () => {
+  const orig = process.env.QERRORS_MAX_FREE_SOCKETS; //save original env value
+  process.env.QERRORS_MAX_FREE_SOCKETS = '100'; //set custom free sockets
+  const { axiosInstance } = reloadQerrors(); //reload with env variable
+  try {
+    assert.equal(axiosInstance.defaults.httpAgent.maxFreeSockets, 100); //http agent uses env
+    assert.equal(axiosInstance.defaults.httpsAgent.maxFreeSockets, 100); //https agent uses env
+  } finally {
+    if (orig === undefined) { delete process.env.QERRORS_MAX_FREE_SOCKETS; } else { process.env.QERRORS_MAX_FREE_SOCKETS = orig; }
+    reloadQerrors(); //reset module state
+  }
+});
+
+test('axiosInstance uses default max free sockets when env missing', () => {
+  const orig = process.env.QERRORS_MAX_FREE_SOCKETS; //capture original env
+  delete process.env.QERRORS_MAX_FREE_SOCKETS; //unset for default test
+  const { axiosInstance } = reloadQerrors(); //reload with defaults
+  try {
+    assert.equal(axiosInstance.defaults.httpAgent.maxFreeSockets, 256); //default http agent value
+    assert.equal(axiosInstance.defaults.httpsAgent.maxFreeSockets, 256); //default https agent value
+  } finally {
+    if (orig === undefined) { delete process.env.QERRORS_MAX_FREE_SOCKETS; } else { process.env.QERRORS_MAX_FREE_SOCKETS = orig; }
+    reloadQerrors(); //restore module state
+  }
+});
+
+test('axiosInstance uses default max free sockets with invalid env', () => { //invalid value fallback
+  const orig = process.env.QERRORS_MAX_FREE_SOCKETS; //preserve original value
+  process.env.QERRORS_MAX_FREE_SOCKETS = 'abc'; //set non-numeric
+  const { axiosInstance } = reloadQerrors(); //reload module with invalid env
+  try {
+    assert.equal(axiosInstance.defaults.httpAgent.maxFreeSockets, 256); //default http agent value
+    assert.equal(axiosInstance.defaults.httpsAgent.maxFreeSockets, 256); //default https agent value
+  } finally {
+    if (orig === undefined) { delete process.env.QERRORS_MAX_FREE_SOCKETS; } else { process.env.QERRORS_MAX_FREE_SOCKETS = orig; }
+    reloadQerrors(); //clean module state
+  }
+});


### PR DESCRIPTION
## Summary
- allow customizing HTTP agent maxFreeSockets
- document QERRORS_MAX_FREE_SOCKETS setting
- add tests for new max free sockets environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684576f639a88322b572da39ef92684c