### PR TITLE
Add queue metrics logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Call `qerrors.purgeExpiredAdvice()` to run a purge instantly. //(manual purge re
 
 Use `qerrors.getQueueLength()` to monitor how many analyses are waiting. //(mention queue length)
 
+The module logs `queueLength` and `queueRejects` every 30s for monitoring. //(document metrics)
 
 QERRORS_MAX_SOCKETS lets you limit how many sockets the http agents open; //document new env var usage
 if not set the default is 50; raise this to handle high traffic. //state default behaviour

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -90,6 +90,8 @@ const limit = createLimiter(CONCURRENCY_LIMIT); //create limiter with stored con
 
 let queueRejectCount = 0; //track how many analyses the queue rejects
 let cleanupHandle = null; //hold interval id for periodic cache purge
+let metricHandle = null; //store interval id for queue metric logging
+const METRIC_INTERVAL_MS = 30000; //emit metrics every thirty seconds
 
 function startAdviceCleanup() { //(kick off periodic advice cleanup)
         if (CACHE_TTL_SECONDS === 0 || ADVICE_CACHE_LIMIT === 0 || cleanupHandle) { return; } //(skip when ttl or cache disabled or already scheduled)
@@ -103,10 +105,28 @@ function stopAdviceCleanup() { //(stop periodic purge when needed)
         cleanupHandle = null; //(reset handle state)
 }
 
+function logQueueMetrics() { //(write queue metrics to logger)
+        logger.then(l => l.info(`metrics queueLength=${getQueueLength()} queueRejects=${getQueueRejectCount()}`));
+        //info level so operators can monitor without triggering qerrors
+}
+
+function startQueueMetrics() { //(begin periodic queue metric logging)
+        if (metricHandle) { return; } //(avoid multiple intervals)
+        metricHandle = setInterval(logQueueMetrics, METRIC_INTERVAL_MS); //(schedule logging every interval)
+        metricHandle.unref(); //(allow process exit without manual cleanup)
+}
+
+function stopQueueMetrics() { //(halt metric emission)
+        if (!metricHandle) { return; } //(no-op when not running)
+        clearInterval(metricHandle); //(cancel metrics interval)
+        metricHandle = null; //(reset handle state)
+}
+
 
 
 async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         startAdviceCleanup(); //(ensure cleanup interval scheduled once)
+        startQueueMetrics(); //(begin metrics interval)
         const total = limit.pendingCount + limit.activeCount; //sum queued and active analyses
         if (total >= QUEUE_LIMIT) { queueRejectCount++; (await logger).warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } //(reject when queue limit reached)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
@@ -438,6 +458,9 @@ module.exports.clearAdviceCache = clearAdviceCache; //export cache clearing func
 module.exports.purgeExpiredAdvice = purgeExpiredAdvice; //export ttl cleanup function
 module.exports.startAdviceCleanup = startAdviceCleanup; //export cleanup scheduler
 module.exports.stopAdviceCleanup = stopAdviceCleanup; //export cleanup canceller
+
+module.exports.startQueueMetrics = startQueueMetrics; //export metrics scheduler
+module.exports.stopQueueMetrics = stopQueueMetrics; //export metrics canceller
 
 module.exports.getQueueLength = getQueueLength; //export queue length
 function getAdviceCacheLimit() { return ADVICE_CACHE_LIMIT; } //expose clamped cache limit for tests


### PR DESCRIPTION
## Summary
- log queue length and queue rejection metrics periodically within qerrors
- describe new metrics in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845770963f883228a0397d57ac23171