### PR TITLE
Add QERRORS_METRIC_INTERVAL_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_TIMEOUT` &ndash; axios request timeout in ms (default `10000`).
 * `QERRORS_MAX_SOCKETS` &ndash; maximum sockets per agent (default `50`, increase for high traffic).
 * `QERRORS_MAX_FREE_SOCKETS` &ndash; maximum idle sockets per agent (default `256`).
+* `QERRORS_METRIC_INTERVAL_MS` &ndash; interval for queue metric logging in milliseconds (default `30000`, set to `0` to disable). //(document metric variable)
 
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
@@ -53,7 +54,7 @@ Call `qerrors.purgeExpiredAdvice()` to run a purge instantly. //(manual purge re
 
 Use `qerrors.getQueueLength()` to monitor how many analyses are waiting. //(mention queue length)
 
-The module logs `queueLength` and `queueRejects` every 30s for monitoring. //(document metrics)
+The module logs `queueLength` and `queueRejects` at a regular interval (default `30s`). Use `QERRORS_METRIC_INTERVAL_MS` to change the period or set `0` to disable logging. //(document metrics)
 
 QERRORS_MAX_SOCKETS lets you limit how many sockets the http agents open; //document new env var usage
 if not set the default is 50; raise this to handle high traffic. //state default behaviour

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,8 @@ const defaults = { //default environment variable values
   QERRORS_VERBOSE: 'true', //enable verbose console logs
   QERRORS_LOG_DIR: 'logs', //directory for rotated logs
   QERRORS_DISABLE_FILE_LOGS: '', //flag to disable file transports when set
-  QERRORS_SERVICE_NAME: 'qerrors' //service identifier for logger //(new default)
+  QERRORS_SERVICE_NAME: 'qerrors', //service identifier for logger //(new default)
+  QERRORS_METRIC_INTERVAL_MS: '30000' //interval for queue metrics in ms //(new default)
 };
 
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -96,7 +96,7 @@ const limit = createLimiter(CONCURRENCY_LIMIT); //create limiter with stored con
 let queueRejectCount = 0; //track how many analyses the queue rejects
 let cleanupHandle = null; //hold interval id for periodic cache purge
 let metricHandle = null; //store interval id for queue metric logging
-const METRIC_INTERVAL_MS = 30000; //emit metrics every thirty seconds
+const METRIC_INTERVAL_MS = config.getInt('QERRORS_METRIC_INTERVAL_MS', 0); //interval for metrics, zero disables
 
 function startAdviceCleanup() { //(kick off periodic advice cleanup)
         if (CACHE_TTL_SECONDS === 0 || ADVICE_CACHE_LIMIT === 0 || cleanupHandle) { return; } //(skip when ttl or cache disabled or already scheduled)
@@ -116,7 +116,7 @@ function logQueueMetrics() { //(write queue metrics to logger)
 }
 
 function startQueueMetrics() { //(begin periodic queue metric logging)
-        if (metricHandle) { return; } //(avoid multiple intervals)
+        if (metricHandle || METRIC_INTERVAL_MS === 0) { return; } //(avoid multiple intervals or disabled)
         metricHandle = setInterval(logQueueMetrics, METRIC_INTERVAL_MS); //(schedule logging every interval)
         metricHandle.unref(); //(allow process exit without manual cleanup)
 }


### PR DESCRIPTION
## Summary
- allow users to control queue metric interval via `QERRORS_METRIC_INTERVAL_MS`
- skip metric scheduler when variable is `0`
- document the new environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68457c2a9d7c83229fe22394f4612015