### PR TITLE
Add max tokens env

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_TIMEOUT` &ndash; axios request timeout in ms (default `10000`).
 * `QERRORS_MAX_SOCKETS` &ndash; maximum sockets per agent (default `50`, increase for high traffic).
 * `QERRORS_MAX_FREE_SOCKETS` &ndash; maximum idle sockets per agent (default `256`).
+* `QERRORS_MAX_TOKENS` &ndash; max tokens for each OpenAI request (default `2048`).
 
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
@@ -59,6 +60,8 @@ QERRORS_MAX_SOCKETS lets you limit how many sockets the http agents open; //docu
 if not set the default is 50; raise this to handle high traffic. //state default behaviour
 QERRORS_MAX_FREE_SOCKETS caps idle sockets the agents keep for reuse; //explain idle setting
 if not set the default is 256 which matches Node's agent default. //state default value
+QERRORS_MAX_TOKENS sets the token limit for OpenAI responses; //describe new env var
+if not set the default is 2048 which balances cost and detail. //state default value
 
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,7 @@ const defaults = { //default environment variable values
   QERRORS_TIMEOUT: '10000', //axios request timeout in ms
   QERRORS_MAX_SOCKETS: '50', //max sockets per http/https agent
   QERRORS_MAX_FREE_SOCKETS: '256', //max idle sockets per agent //(new env default)
+  QERRORS_MAX_TOKENS: '2048', //max tokens for openai responses //(new env default)
 
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -263,7 +263,7 @@ async function analyzeError(error, context) {
                 messages: [{ role: 'user', content: errorPrompt }], //prompt to analyze error
                 response_format: { type: 'json_object' }, //structured response expected
                 temperature: 1, //creative but focused suggestions
-                max_tokens: 2048, //limit response length
+                max_tokens: config.getInt('QERRORS_MAX_TOKENS'), //limit response length using env
                 top_p: 1, //full vocabulary access
                 frequency_penalty: 0, //allow repetition when useful
                 presence_penalty: 0 //permit technical term usage

--- a/test/maxTokens.test.js
+++ b/test/maxTokens.test.js
@@ -1,0 +1,77 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stub utilities
+
+function reloadQerrors() { //reload module to apply env vars
+  delete require.cache[require.resolve('../lib/qerrors')];
+  delete require.cache[require.resolve('../lib/config')];
+  return require('../lib/qerrors');
+}
+
+function withToken(token) { //temporarily set OPENAI_TOKEN
+  const orig = process.env.OPENAI_TOKEN; //save original
+  if (token === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = token; }
+  return () => { //restore previous value
+    if (orig === undefined) { delete process.env.OPENAI_TOKEN; } else { process.env.OPENAI_TOKEN = orig; }
+  };
+}
+
+test('analyzeError uses QERRORS_MAX_TOKENS', async () => {
+  const restoreToken = withToken('tok'); //provide token for API
+  const orig = process.env.QERRORS_MAX_TOKENS; //capture original value
+  process.env.QERRORS_MAX_TOKENS = '4096'; //set custom env
+  const fresh = reloadQerrors(); //reload with new env
+  const capture = {}; //store axios call
+  const restoreAxios = qtests.stubMethod(fresh.axiosInstance, 'post', async (u, b) => { capture.body = b; return { data: { choices: [{ message: { content: {} } }] } }; }); //stub post
+  try {
+    const err = new Error('tok');
+    err.uniqueErrorName = 'TOK1';
+    await fresh.analyzeError(err, 'ctx');
+  } finally {
+    restoreAxios();
+    if (orig === undefined) { delete process.env.QERRORS_MAX_TOKENS; } else { process.env.QERRORS_MAX_TOKENS = orig; }
+    reloadQerrors();
+    restoreToken();
+  }
+  assert.equal(capture.body.max_tokens, 4096); //expect env value used
+});
+
+test('analyzeError defaults QERRORS_MAX_TOKENS when unset', async () => {
+  const restoreToken = withToken('tok');
+  const orig = process.env.QERRORS_MAX_TOKENS; //save env
+  delete process.env.QERRORS_MAX_TOKENS; //unset variable
+  const fresh = reloadQerrors(); //reload for defaults
+  const capture = {}; //capture post body
+  const restoreAxios = qtests.stubMethod(fresh.axiosInstance, 'post', async (u, b) => { capture.body = b; return { data: { choices: [{ message: { content: {} } }] } }; });
+  try {
+    const err = new Error('def');
+    err.uniqueErrorName = 'TOKDEF';
+    await fresh.analyzeError(err, 'ctx');
+  } finally {
+    restoreAxios();
+    if (orig === undefined) { delete process.env.QERRORS_MAX_TOKENS; } else { process.env.QERRORS_MAX_TOKENS = orig; }
+    reloadQerrors();
+    restoreToken();
+  }
+  assert.equal(capture.body.max_tokens, 2048); //default should apply
+});
+
+test('analyzeError defaults QERRORS_MAX_TOKENS with invalid env', async () => {
+  const restoreToken = withToken('tok');
+  const orig = process.env.QERRORS_MAX_TOKENS; //store current
+  process.env.QERRORS_MAX_TOKENS = 'abc'; //invalid value
+  const fresh = reloadQerrors(); //reload module
+  const capture = {}; //capture body
+  const restoreAxios = qtests.stubMethod(fresh.axiosInstance, 'post', async (u, b) => { capture.body = b; return { data: { choices: [{ message: { content: {} } }] } }; });
+  try {
+    const err = new Error('bad');
+    err.uniqueErrorName = 'TOKBAD';
+    await fresh.analyzeError(err, 'ctx');
+  } finally {
+    restoreAxios();
+    if (orig === undefined) { delete process.env.QERRORS_MAX_TOKENS; } else { process.env.QERRORS_MAX_TOKENS = orig; }
+    reloadQerrors();
+    restoreToken();
+  }
+  assert.equal(capture.body.max_tokens, 2048); //invalid falls back
+});


### PR DESCRIPTION
## Summary
- support new env `QERRORS_MAX_TOKENS` for OpenAI requests
- document token variable in README
- use env value in `openaiBody`
- test new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68457c394d648322a74a495cfe4ba7e0