### PR TITLE
Add QERRORS_LOG_LEVEL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_VERBOSE` &ndash; enable console logging (`true` by default). Set `QERRORS_VERBOSE=false` for production deployments to keep logs from flooding the console and rely on file output instead.
 * `QERRORS_LOG_DIR` &ndash; directory for logger output (default `logs`).
 * `QERRORS_DISABLE_FILE_LOGS` &ndash; disable file transports when set.
+* `QERRORS_LOG_LEVEL` &ndash; logger output level (default `info`). //(document log level)
 * `QERRORS_SERVICE_NAME` &ndash; service name added to logger metadata (default `qerrors`). //(document service variable)
 
 For high traffic scenarios raise `QERRORS_CONCURRENCY`, `QERRORS_QUEUE_LIMIT`, `QERRORS_MAX_SOCKETS`, and `QERRORS_MAX_FREE_SOCKETS`. Set `QERRORS_VERBOSE=false` in production to reduce console overhead.

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,8 @@ const defaults = { //default environment variable values
   QERRORS_VERBOSE: 'true', //enable verbose console logs
   QERRORS_LOG_DIR: 'logs', //directory for rotated logs
   QERRORS_DISABLE_FILE_LOGS: '', //flag to disable file transports when set
-  QERRORS_SERVICE_NAME: 'qerrors' //service identifier for logger //(new default)
+  QERRORS_SERVICE_NAME: 'qerrors', //service identifier for logger //(new default)
+  QERRORS_LOG_LEVEL: 'info' //logger output severity default
 };
 
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -49,9 +49,9 @@ async function initLogDir() { //prepare log directory asynchronously
 async function buildLogger() { //create logger after dir ready
         await initLogDir(); //ensure directory exists before transports
         const log = createLogger({
-	// Info level captures errors, warnings, and informational messages
-	// This provides comprehensive logging without debug noise in production
-	level: 'info',
+        // Log level from QERRORS_LOG_LEVEL environment variable
+        // Defaults to 'info' allowing errors, warnings, and info messages
+        level: config.getEnv('QERRORS_LOG_LEVEL'), //env configurable log level
 	
 	// Combined format pipeline processes logs through multiple transformations
 	// Order matters: timestamp first, then error handling, then formatting

--- a/test/logLevel.test.js
+++ b/test/logLevel.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+const winston = require('winston'); //winston stub
+
+function reloadLogger() { //reload logger with env changes
+  delete require.cache[require.resolve('../lib/logger')];
+  delete require.cache[require.resolve('../lib/config')];
+  return require('../lib/logger');
+}
+
+test('logger uses QERRORS_LOG_LEVEL env var', async () => {
+  const orig = process.env.QERRORS_LOG_LEVEL; //save original value
+  process.env.QERRORS_LOG_LEVEL = 'debug'; //set custom level
+  let captured; //capture config
+  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { level: cfg.level, transports: cfg.transports, warn() {}, info() {}, error() {} }; }); //return stub logger
+  const logger = await reloadLogger();
+  try {
+    assert.equal(captured.level, 'debug');
+    assert.equal((await logger).level, 'debug');
+  } finally {
+    restore();
+    if (orig === undefined) { delete process.env.QERRORS_LOG_LEVEL; } else { process.env.QERRORS_LOG_LEVEL = orig; }
+    reloadLogger(); //reset cache
+  }
+});
+
+test('logger defaults QERRORS_LOG_LEVEL when unset', async () => {
+  const orig = process.env.QERRORS_LOG_LEVEL; //store original
+  delete process.env.QERRORS_LOG_LEVEL; //unset for default test
+  let captured; //capture config
+  const restore = qtests.stubMethod(winston, 'createLogger', cfg => { captured = cfg; return { level: cfg.level, transports: cfg.transports, warn() {}, info() {}, error() {} }; }); //return stub logger
+  const logger = await reloadLogger();
+  try {
+    assert.equal(captured.level, 'info');
+    assert.equal((await logger).level, 'info');
+  } finally {
+    restore();
+    if (orig === undefined) { delete process.env.QERRORS_LOG_LEVEL; } else { process.env.QERRORS_LOG_LEVEL = orig; }
+    reloadLogger(); //reset cache
+  }
+});


### PR DESCRIPTION
## Summary
- support `QERRORS_LOG_LEVEL` configuration in config and logger
- document the new variable in README
- test logger level behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68457c4ac9508322b32ca5dfc979852e