### PR TITLE
Handle cleanup stop when cache empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Call `qerrors.clearAdviceCache()` to manually empty the advice cache. //(documen
 Use `qerrors.startAdviceCleanup()` to begin automatic purging of expired entries. //(document cleanup scheduler)
 Call `qerrors.stopAdviceCleanup()` if you need to halt the cleanup interval. //(document cleanup stop)
 Call `qerrors.purgeExpiredAdvice()` to run a purge instantly. //(manual purge reminder)
+After each purge or clear operation the module checks the cache size and stops cleanup when it reaches zero, restarting the interval when new advice is cached. //(document cleanup auto stop/start)
 
 Use `qerrors.getQueueLength()` to monitor how many analyses are waiting. //(mention queue length)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,7 +23,7 @@ const defaults = { //default environment variable values
   QERRORS_DISABLE_FILE_LOGS: '', //flag to disable file transports when set
   QERRORS_SERVICE_NAME: 'qerrors', //service identifier for logger //(new default)
 
-  QERRORS_LOG_LEVEL: 'info' //logger output severity default
+  QERRORS_LOG_LEVEL: 'info', //logger output severity default
 
   QERRORS_METRIC_INTERVAL_MS: '30000' //interval for queue metrics in ms //(new default)
 

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -141,11 +141,11 @@ async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
 function getQueueRejectCount() { return queueRejectCount; } //expose reject count
 
 
-function clearAdviceCache() { adviceCache.clear(); } //empty cache via LRU method
+function clearAdviceCache() { adviceCache.clear(); if (adviceCache.size === 0) { stopAdviceCleanup(); } } //empty cache and stop interval when empty
 
 function purgeExpiredAdvice() { //trigger lru-cache cleanup cycle
         if (CACHE_TTL_SECONDS === 0 || ADVICE_CACHE_LIMIT === 0) { return; } //skip when ttl or cache disabled
-        adviceCache.purgeStale(); //remove expired entries using library
+        adviceCache.purgeStale(); if (adviceCache.size === 0) { stopAdviceCleanup(); } //remove expired entries and stop interval when empty
 } //lru-cache handles its own batch logic
 
 function getQueueLength() { return limit.pendingCount; } //expose queue length
@@ -297,12 +297,12 @@ async function analyzeError(error, context) {
 		// Handle structured response with data property
                 if (advice.data) {
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice.data)}`); //(stringify advice.data for consistent logging)
-                        if (ADVICE_CACHE_LIMIT !== 0) { adviceCache.set(error.qerrorsKey, advice); } //cache structured advice
+                        if (ADVICE_CACHE_LIMIT !== 0) { adviceCache.set(error.qerrorsKey, advice); startAdviceCleanup(); } //cache structured advice and ensure interval
                         return advice;
                 } else if (advice) {
                         // Handle direct advice object
                         verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice object for consistent logging)
-                        if (ADVICE_CACHE_LIMIT !== 0) { adviceCache.set(error.qerrorsKey, advice); } //cache direct advice
+                        if (ADVICE_CACHE_LIMIT !== 0) { adviceCache.set(error.qerrorsKey, advice); startAdviceCleanup(); } //cache direct advice and ensure interval
                         return advice;
                 }
 	} else {


### PR DESCRIPTION
## Summary
- stop the cleanup interval when `adviceCache` becomes empty
- restart the cleanup when new advice entries are cached
- fix syntax error in `config.js`
- document automatic cleanup behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684685044cdc8322a6fe15660f0ba9ed