### PR TITLE
Resolve logger once

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -17,6 +17,7 @@
 const config = require('./config'); //load default environment variables and helpers
 
 const logger = require('./logger'); //centralized winston logger configuration promise
+let log; const logPromise = logger; logPromise.then(l => { log = l; }); //resolve logger once and set log variable
 const axios = require('axios'); //HTTP client used for OpenAI API calls
 const http = require('http'); //node http for agent keep alive
 const https = require('https'); //node https for agent keep alive
@@ -63,20 +64,20 @@ const rawQueue = config.getInt('QERRORS_QUEUE_LIMIT'); //(raw queue limit from e
 const SAFE_THRESHOLD = config.getInt('QERRORS_SAFE_THRESHOLD'); //limit considered safe for concurrency and queue without enforced minimum //(configurable)
 const CONCURRENCY_LIMIT = Math.min(rawConc, SAFE_THRESHOLD); //(clamp concurrency to safe threshold)
 const QUEUE_LIMIT = Math.min(rawQueue, SAFE_THRESHOLD); //(clamp queue limit to safe threshold)
-if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logger.then(l => l.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`)); } //(warn when original limits exceed threshold)
+if (rawConc > SAFE_THRESHOLD || rawQueue > SAFE_THRESHOLD) { logPromise.then(l => l.warn(`High qerrors limits clamped conc ${rawConc} queue ${rawQueue}`)); } //(warn when original limits exceed threshold)
 
 const rawSockets = config.getInt('QERRORS_MAX_SOCKETS'); //raw sockets from env
 const MAX_SOCKETS = Math.min(rawSockets, SAFE_THRESHOLD); //clamp sockets to safe threshold
-if (rawSockets > SAFE_THRESHOLD) { logger.then(l => l.warn(`max sockets clamped ${rawSockets}`)); } //warn on clamp when limit exceeded
+if (rawSockets > SAFE_THRESHOLD) { logPromise.then(l => l.warn(`max sockets clamped ${rawSockets}`)); } //warn on clamp when limit exceeded
 
 const rawFreeSockets = config.getInt('QERRORS_MAX_FREE_SOCKETS'); //raw free socket count from env //(new env)
 const MAX_FREE_SOCKETS = Math.min(rawFreeSockets, SAFE_THRESHOLD); //clamp free sockets to safe threshold //(new const)
-if (rawFreeSockets > SAFE_THRESHOLD) { logger.then(l => l.warn(`max free sockets clamped ${rawFreeSockets}`)); } //warn when clamped //(new warn)
+if (rawFreeSockets > SAFE_THRESHOLD) { logPromise.then(l => l.warn(`max free sockets clamped ${rawFreeSockets}`)); } //warn when clamped //(new warn)
 
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : Math.min(parsedLimit, SAFE_THRESHOLD); //clamp to safe threshold when >0
-if (parsedLimit > SAFE_THRESHOLD) { logger.warn(`cache limit clamped ${parsedLimit}`); } //warn on clamp similar to other limits
+if (parsedLimit > SAFE_THRESHOLD) { logPromise.then(l => l.warn(`cache limit clamped ${parsedLimit}`)); } //warn on clamp similar to other limits
 const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
 const adviceCache = new LRUCache({ max: ADVICE_CACHE_LIMIT || 0, ttl: CACHE_TTL_SECONDS * 1000 }); //create cache with ttl and max settings
@@ -111,7 +112,7 @@ function stopAdviceCleanup() { //(stop periodic purge when needed)
 }
 
 function logQueueMetrics() { //(write queue metrics to logger)
-        logger.then(l => l.info(`metrics queueLength=${getQueueLength()} queueRejects=${getQueueRejectCount()}`));
+        logPromise.then(l => l.info(`metrics queueLength=${getQueueLength()} queueRejects=${getQueueRejectCount()}`));
         //info level so operators can monitor without triggering qerrors
 }
 
@@ -133,7 +134,7 @@ async function scheduleAnalysis(err, ctx) { //limit analyzeError concurrency
         startAdviceCleanup(); //(ensure cleanup interval scheduled once)
         startQueueMetrics(); //(begin metrics interval)
         const total = limit.pendingCount + limit.activeCount; //sum queued and active analyses
-        if (total >= QUEUE_LIMIT) { queueRejectCount++; (await logger).warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } //(reject when queue limit reached)
+        if (total >= QUEUE_LIMIT) { queueRejectCount++; log.warn(`analysis queue full pending ${limit.pendingCount} active ${limit.activeCount}`); return Promise.reject(new Error('queue full')); } //(reject when queue limit reached)
         return limit(() => analyzeError(err, ctx)); //queue via p-limit and return its promise
 
 }
@@ -388,7 +389,7 @@ async function qerrors(error, context, req, res, next) {
 	
 	// Log error through winston logger for persistent storage and processing
 	// Uses structured logging format compatible with log aggregation systems
-        (await logger).error(errorLog);
+        log.error(errorLog); //use logger instance without awaiting each call
 	
 
 	
@@ -442,7 +443,7 @@ async function qerrors(error, context, req, res, next) {
 
         Promise.resolve() //start async analysis without blocking response
                 .then(() => scheduleAnalysis(error, context)) //invoke queued analysis after sending response
-                .catch(async (analysisErr) => (await logger).error(analysisErr)); //log any scheduleAnalysis failures
+                .catch((analysisErr) => log.error(analysisErr)); //log any scheduleAnalysis failures
 
         verboseLog(`qerrors ran`); //log completion after scheduling analysis
 }
@@ -470,4 +471,5 @@ module.exports.stopQueueMetrics = stopQueueMetrics; //export metrics canceller
 module.exports.getQueueLength = getQueueLength; //export queue length
 function getAdviceCacheLimit() { return ADVICE_CACHE_LIMIT; } //expose clamped cache limit for tests
 module.exports.getAdviceCacheLimit = getAdviceCacheLimit; //export clamp accessor
+module.exports.logger = logger; //export original logger promise for external use
 


### PR DESCRIPTION
## Summary
- initialize logger once at module load
- update logger calls to use resolved instance
- export logger promise

## Testing
- `npm test` *(fails: SyntaxError in config.js, missing modules like winston)*

------
https://chatgpt.com/codex/tasks/task_b_68468518caa88322b41601e080aa3b02