### PR TITLE
Update clamp docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ to resolve errors.
 qerrors reads several environment variables to tune its behavior. A small configuration file in the library sets sensible defaults when these variables are not defined. Only `OPENAI_TOKEN` must be provided manually to enable AI analysis. Obtain your key from [OpenAI](https://openai.com) and set the variable in your environment.
 
 * `OPENAI_TOKEN` &ndash; your OpenAI API key.
-* `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic, values over `1000` are clamped). //(document clamp)
+* `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic, values over `QERRORS_SAFE_THRESHOLD` are clamped).
 
 * `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching, values over `1000` are clamped).
 * `QERRORS_CACHE_TTL` &ndash; seconds before cached advice expires (default `86400`).
-* `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load, values over `1000` are clamped). //(document queue clamp)
-* `QERRORS_SAFE_THRESHOLD` &ndash; maximum allowed value for `QERRORS_CONCURRENCY` and `QERRORS_QUEUE_LIMIT` before clamping occurs (default `1000`). //(document configurable safe clamp)
+* `QERRORS_QUEUE_LIMIT` &ndash; maximum queued analyses before rejecting new ones (default `100`, raise when under heavy load, values over `QERRORS_SAFE_THRESHOLD` are clamped).
+* `QERRORS_SAFE_THRESHOLD` &ndash; limit at which `QERRORS_CONCURRENCY` and `QERRORS_QUEUE_LIMIT` are clamped (default `1000`, increase to raise their allowed upper bound).
 
 
 * `QERRORS_RETRY_ATTEMPTS` &ndash; attempts when calling OpenAI (default `2`).


### PR DESCRIPTION
## Summary
- clarify that QERRORS_CONCURRENCY and QERRORS_QUEUE_LIMIT clamp using QERRORS_SAFE_THRESHOLD
- note that QERRORS_SAFE_THRESHOLD can be increased

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468d8b25e48322b8e59b1a9b793a81