### PR TITLE
Add configurable OpenAI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ to resolve errors.
 qerrors reads several environment variables to tune its behavior. A small configuration file in the library sets sensible defaults when these variables are not defined. Only `OPENAI_TOKEN` must be provided manually to enable AI analysis. Obtain your key from [OpenAI](https://openai.com) and set the variable in your environment.
 
 * `OPENAI_TOKEN` &ndash; your OpenAI API key.
+* `QERRORS_OPENAI_URL` &ndash; OpenAI API endpoint (default `https://api.openai.com/v1/chat/completions`).
 * `QERRORS_CONCURRENCY` &ndash; maximum concurrent analyses (default `5`, raise for high traffic, values over `1000` are clamped). //(document clamp)
 
 * `QERRORS_CACHE_LIMIT` &ndash; size of the advice cache (default `50`, set to `0` to disable caching, values over `1000` are clamped).

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ const defaults = { //default environment variable values
   QERRORS_MAX_SOCKETS: '50', //max sockets per http/https agent
   QERRORS_MAX_FREE_SOCKETS: '256', //max idle sockets per agent //(new env default)
   QERRORS_MAX_TOKENS: '2048', //max tokens for openai responses //(new env default)
+  QERRORS_OPENAI_URL: 'https://api.openai.com/v1/chat/completions', //endpoint used for analysis //(new openai url default)
 
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files

--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -272,7 +272,7 @@ async function analyzeError(error, context) {
                 presence_penalty: 0 //permit technical term usage
         };
         try {
-                response = await module.exports.postWithRetry('https://api.openai.com/v1/chat/completions', openaiBody, { //use helper for retries
+                response = await module.exports.postWithRetry(config.getEnv('QERRORS_OPENAI_URL'), openaiBody, { //use env url for retry //(use new env)
                         headers: {
                                 'Authorization': `Bearer ${process.env.OPENAI_TOKEN}`,
                                 'Content-Type': 'application/json'

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -8,6 +8,7 @@ const qerrorsModule = require('../lib/qerrors'); //import module under test
 const { analyzeError } = qerrorsModule; //extract analyzeError for direct calls
 const { axiosInstance } = qerrorsModule; //instance used inside analyzeError
 const { postWithRetry } = qerrorsModule; //helper used for retrying requests
+const config = require('../lib/config'); //load env defaults for assertions //(new import)
 
 
 function withOpenAIToken(token) { //(temporarily set OPENAI_TOKEN)
@@ -81,7 +82,7 @@ test('analyzeError processes JSON response from API', async () => {
     const result = await analyzeError(err, 'test context');
     assert.ok(result);
     assert.equal(result.advice, 'test advice');
-    assert.equal(capture.url, 'https://api.openai.com/v1/chat/completions'); //(assert api endpoint used)
+    assert.equal(capture.url, config.getEnv('QERRORS_OPENAI_URL')); //(assert api endpoint used)
     assert.equal(capture.body.model, 'gpt-4.1'); //(validate model in request body)
     assert.ok(Array.isArray(capture.body.messages)); //(ensure messages array sent)
     assert.equal(capture.body.messages[0].role, 'user'); //(first message role should be user)


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI endpoint via `QERRORS_OPENAI_URL`
- use new variable in `analyzeError`
- document the variable in README
- adjust tests for the new environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468d914d348322bb624d6af1055078