### PR TITLE
Implement verbose performance warning

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -48,7 +48,7 @@ async function initLogDir() { //prepare log directory asynchronously
  */
 async function buildLogger() { //create logger after dir ready
         await initLogDir(); //ensure directory exists before transports
-        const log = createLogger({
+       const log = createLogger({ //build configured winston logger instance
         // Log level from QERRORS_LOG_LEVEL environment variable
         // Defaults to 'info' allowing errors, warnings, and info messages
         level: config.getEnv('QERRORS_LOG_LEVEL'), //env configurable log level
@@ -99,9 +99,10 @@ async function buildLogger() { //create logger after dir ready
                if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //console only when verbose
                return arr; //provide configured transports
         })()
-        });
-        if (maxDays === 0 && !disableFileLogs) { log.warn('QERRORS_LOG_MAX_DAYS is 0; log files may grow without bound'); } //(warn about unlimited log retention)
-        return log; //provide created logger
+       });
+       if (process.env.QERRORS_VERBOSE === 'true') { log.warn('QERRORS_VERBOSE=true can impact performance at scale'); } //warn when verbose may slow logging
+       if (maxDays === 0 && !disableFileLogs) { log.warn('QERRORS_LOG_MAX_DAYS is 0; log files may grow without bound'); } //(warn about unlimited log retention)
+       return log; //provide created logger
 }
 
 const logger = buildLogger(); //async logger promise


### PR DESCRIPTION
## Summary
- warn when running with verbose logging enabled
- expect verbose warning in verbose unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68468da15c0083228dcac49222e8a091