### PR TITLE
Update logger formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ log.error('An error occurred', { errorDetails: error });
 - **Graceful Degradation**: Functions normally even without OpenAI API access
 - **Comprehensive Logging**: Multi-transport Winston logging with file rotation
 
+### Logging
+
+File transports output JSON objects with timestamps and stack traces. Console
+output, enabled when `QERRORS_VERBOSE=true`, uses a compact printf format for
+readability.
+
 ### Error Response Formats
 
 **HTML Response** (for browsers):

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -24,6 +24,20 @@ const rotationOpts = { maxsize: Number(process.env.QERRORS_LOG_MAXSIZE) || 1024 
 const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(controls time rotation)
 const logDir = process.env.QERRORS_LOG_DIR || 'logs'; //directory to store log files
 let disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //track file log state //(respect env flag)
+
+const fileFormat = format.combine( //formatter for JSON file logs with timestamp and stack
+        format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), //timestamp for chronological sorting
+        format.errors({ stack: true }), //include stack traces in log object
+        format.splat(), //enable printf style interpolation
+        format.json() //output structured JSON for log processors
+); //makes structured logs easy to parse
+
+const consoleFormat = format.combine( //formatter for readable console output
+        format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), //timestamp for readability
+        format.errors({ stack: true }), //include stack
+        format.splat(), //support sprintf like syntax
+        format.printf(({ timestamp, level, message, stack }) => `${timestamp} ${level}: ${message}${stack ? '\n' + stack : ''}`) //custom printable string
+); //keeps console output compact and readable
 /**
  * Asynchronously initializes the logging directory structure
  * 
@@ -52,40 +66,29 @@ async function initLogDir() { //prepare log directory asynchronously ensuring pr
  * 2. Combined file for comprehensive audit trail and debugging
  * 3. Console for immediate development feedback and debugging
  *
- * Format strategy combines multiple Winston formatters:
- * - Timestamp: Consistent chronological ordering across environments
- * - Errors: Proper stack trace handling for Error objects
- * - Splat: Support for printf-style string interpolation
- * - JSON: Structured data for log analysis tools
- * - Printf: Human-readable final format for console output
+ * Format strategy uses dedicated configurations:
+ * - File transports log JSON for ingestion by aggregation tools
+ * - Console transport uses printf for readable development output
+ * - Each includes timestamp, stack traces and splat interpolation
  */
 async function buildLogger() { //(create logger after directory preparation complete)
         await initLogDir(); //(ensure directory exists before configuring file transports)
        const log = createLogger({ //(build configured winston logger instance with multi-transport setup)
         level: config.getEnv('QERRORS_LOG_LEVEL'), //(log level from env variable defaulting to 'info' for errors, warnings, and info messages)
-        format: format.combine( //(combined format pipeline processes logs through multiple transformations, order matters for proper processing)
-                format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }), //(standardized timestamp format ensures consistent chronological sorting and international compatibility)
-                format.errors({ stack: true }), //(specialized handling for Error objects to capture stack traces, critical since Error objects don't stringify stacks by default)
-                format.splat(), //(enable printf-style string interpolation in log messages for flexible formatting like logger.info('User %s logged in', username))
-                format.json(), //(JSON format for structured logging and compatibility with log aggregation tools, essential for production centralized logging)
-                format.printf(({ timestamp, level, message, stack }) => {
-                        return `${timestamp} ${level}: ${message}${stack ? '\n' + stack : ''}`;
-                }) //(custom printf formatter for human-readable console output, conditionally includes stack trace to avoid clutter in normal messages)
-        ),
         defaultMeta: { service: config.getEnv('QERRORS_SERVICE_NAME') }, //(default metadata added to all log entries, service identification helps in multi-service environments)
         transports: (() => { //(multi-transport configuration for comprehensive log coverage)
                const arr = []; //(start with empty transport array)
                if (!disableFileLogs) { //(add file transports when directory creation successful)
                         if (maxDays > 0) { //(use daily rotation when retention period configured)
-                                arr.push(new DailyRotateFile({ filename: path.join(logDir, 'error-%DATE%.log'), level: 'error', datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize })); //(error-only file with daily rotation for focused error analysis)
-                                arr.push(new DailyRotateFile({ filename: path.join(logDir, 'combined-%DATE%.log'), datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize })); //(combined log file with daily rotation for comprehensive audit trail)
+                                arr.push(new DailyRotateFile({ filename: path.join(logDir, 'error-%DATE%.log'), level: 'error', datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize, format: fileFormat })); //(error-only file with daily rotation for focused error analysis)
+                                arr.push(new DailyRotateFile({ filename: path.join(logDir, 'combined-%DATE%.log'), datePattern: 'YYYY-MM-DD', maxFiles: `${maxDays}d`, maxSize: rotationOpts.maxsize, format: fileFormat })); //(combined log file with daily rotation for comprehensive audit trail)
                         } else {
                                 const fileCap = rotationOpts.maxFiles > 0 ? rotationOpts.maxFiles : 30; //(fallback file count cap when time rotation disabled)
-                                arr.push(new transports.File({ filename: path.join(logDir, 'error.log'), level: 'error', ...rotationOpts, maxFiles: fileCap })); //(size-based rotation for error files with count limit)
-                                arr.push(new transports.File({ filename: path.join(logDir, 'combined.log'), ...rotationOpts, maxFiles: fileCap })); //(size-based rotation for combined files with count limit)
+                                arr.push(new transports.File({ filename: path.join(logDir, 'error.log'), level: 'error', ...rotationOpts, maxFiles: fileCap, format: fileFormat })); //(size-based rotation for error files with count limit)
+                                arr.push(new transports.File({ filename: path.join(logDir, 'combined.log'), ...rotationOpts, maxFiles: fileCap, format: fileFormat })); //(size-based rotation for combined files with count limit)
                         }
                }
-               if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console()); } //(console transport only when verbose mode enabled)
+               if (process.env.QERRORS_VERBOSE === 'true') { arr.push(new transports.Console({ format: consoleFormat })); } //(console transport only when verbose mode enabled)
                return arr; //(return configured transport array)
         })()
        });


### PR DESCRIPTION
## Summary
- separate JSON and printf formats for winston
- log JSON to file transports and printf to console
- document file/console formats

## Testing
- `npm test` *(fails: Cannot find module 'escape-html')*

------
https://chatgpt.com/codex/tasks/task_b_6848d16341008322a363ba3eb9881d0a