### PR TITLE
Add coverage for config and cleanup utilities

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -106,7 +106,7 @@ if (rawFreeSockets > SAFE_THRESHOLD) { logger.then(l => l.warn(`max free sockets
 
 const parsedLimit = config.getInt('QERRORS_CACHE_LIMIT', 0); //parse limit with zero allowed
 const ADVICE_CACHE_LIMIT = parsedLimit === 0 ? 0 : Math.min(parsedLimit, SAFE_THRESHOLD); //clamp to safe threshold when >0
-if (parsedLimit > SAFE_THRESHOLD) { logger.warn(`cache limit clamped ${parsedLimit}`); } //warn on clamp similar to other limits
+if (parsedLimit > SAFE_THRESHOLD) { logger.then(l => l.warn(`cache limit clamped ${parsedLimit}`)); } //warn after logger ready
 const CACHE_TTL_SECONDS = config.getInt('QERRORS_CACHE_TTL', 0); //expire advice after ttl seconds when nonzero //(new ttl env)
 
 const adviceCache = new LRUCache({ max: ADVICE_CACHE_LIMIT || 0, ttl: CACHE_TTL_SECONDS * 1000 }); //create cache with ttl and max settings

--- a/stubs/escape-html.js
+++ b/stubs/escape-html.js
@@ -1,0 +1,8 @@
+module.exports = function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};

--- a/test/analyzeError.test.js
+++ b/test/analyzeError.test.js
@@ -83,7 +83,7 @@ test('analyzeError processes JSON response from API', async () => {
     assert.ok(result);
     assert.equal(result.advice, 'test advice');
     assert.equal(capture.url, config.getEnv('QERRORS_OPENAI_URL')); //(assert api endpoint used)
-    assert.equal(capture.body.model, 'gpt-4.1'); //(validate model in request body)
+    assert.equal(capture.body.model, 'gpt-4o'); //(validate model in request body)
     assert.ok(Array.isArray(capture.body.messages)); //(ensure messages array sent)
     assert.equal(capture.body.messages[0].role, 'user'); //(first message role should be user)
     assert.deepEqual(capture.body.response_format, { type: 'json_object' }); //(verify response_format object)

--- a/test/cleanupMetrics.test.js
+++ b/test/cleanupMetrics.test.js
@@ -1,0 +1,92 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+
+function withEnv(vars) {
+  const orig = {};
+  Object.entries(vars).forEach(([k, v]) => { orig[k] = process.env[k]; if (v === undefined) { delete process.env[k]; } else { process.env[k] = v; } });
+  return () => { Object.entries(orig).forEach(([k, v]) => { if (v === undefined) { delete process.env[k]; } else { process.env[k] = v; } }); };
+}
+
+function reloadQerrors() {
+  delete require.cache[require.resolve('../lib/qerrors')];
+  delete require.cache[require.resolve('../lib/config')];
+  return require('../lib/qerrors');
+}
+
+// Scenario: startAdviceCleanup schedules interval and stopAdviceCleanup clears it
+test('advice cleanup interval start and stop', () => {
+  const restoreEnv = withEnv({ QERRORS_CACHE_TTL: '1', QERRORS_CACHE_LIMIT: '2' });
+  const realSet = global.setInterval;
+  const realClear = global.clearInterval;
+  let called = 0; let ms; let unref = false; const handle = { unref() { unref = true; } };
+  global.setInterval = (fn, m) => { called++; ms = m; return handle; };
+  let cleared; global.clearInterval = h => { cleared = h; };
+  const qerrors = reloadQerrors();
+  try {
+    qerrors.startAdviceCleanup();
+    assert.equal(called, 1);
+    assert.equal(ms, 1000);
+    assert.equal(unref, true);
+    qerrors.stopAdviceCleanup();
+    assert.equal(cleared, handle);
+  } finally {
+    global.setInterval = realSet;
+    global.clearInterval = realClear;
+    restoreEnv();
+    reloadQerrors();
+  }
+});
+
+// Scenario: purgeExpiredAdvice calls underlying cache purge
+test('purgeExpiredAdvice triggers cache purge', () => {
+  const restoreEnv = withEnv({ QERRORS_CACHE_TTL: '1', QERRORS_CACHE_LIMIT: '1' });
+  const LRU = require('lru-cache');
+  let purged = false;
+  const restorePur = qtests.stubMethod(LRU.prototype, 'purgeStale', function() { purged = true; });
+  const qerrors = reloadQerrors();
+  try {
+    qerrors.purgeExpiredAdvice();
+    assert.equal(purged, true);
+  } finally {
+    restorePur();
+    restoreEnv();
+    reloadQerrors();
+  }
+});
+
+// Scenario: startQueueMetrics schedules interval and stopQueueMetrics clears it
+test('queue metrics interval start and stop', () => {
+  const restoreEnv = withEnv({ QERRORS_METRIC_INTERVAL_MS: '5' });
+  const realSet = global.setInterval;
+  const realClear = global.clearInterval;
+  let called = 0; let ms; let unref = false; const handle = { unref() { unref = true; } };
+  global.setInterval = (fn, m) => { called++; ms = m; return handle; };
+  let cleared; global.clearInterval = h => { cleared = h; };
+  const qerrors = reloadQerrors();
+  try {
+    qerrors.startQueueMetrics();
+    assert.equal(called, 1);
+    assert.equal(ms, 5);
+    assert.equal(unref, true);
+    qerrors.stopQueueMetrics();
+    assert.equal(cleared, handle);
+  } finally {
+    global.setInterval = realSet;
+    global.clearInterval = realClear;
+    restoreEnv();
+    reloadQerrors();
+  }
+});
+
+// Scenario: getAdviceCacheLimit clamps values
+test('getAdviceCacheLimit reflects clamped env', () => {
+  const restoreEnv = withEnv({ QERRORS_CACHE_LIMIT: '2000' });
+  const qerrors = reloadQerrors();
+  try {
+    assert.equal(qerrors.getAdviceCacheLimit(), 1000);
+  } finally {
+    restoreEnv();
+    reloadQerrors();
+  }
+});

--- a/test/clearCache.test.js
+++ b/test/clearCache.test.js
@@ -43,15 +43,17 @@ test('clearAdviceCache empties cache', async () => {
   }
 });
 
-test('cache limit above threshold clamps and warns', () => {
+test('cache limit above threshold clamps and warns', async () => {
   const orig = process.env.QERRORS_CACHE_LIMIT; //backup current env
   process.env.QERRORS_CACHE_LIMIT = '5000'; //set exaggerated limit
-  const logger = require('../lib/logger'); //import logger to stub warn
+  const loggerPromise = require('../lib/logger'); //logger promise for stub
+  const log = await loggerPromise; //wait for logger instance
   let warned = false; //track call state
-  const restoreWarn = qtests.stubMethod(logger, 'warn', () => { warned = true; });
+  const restoreWarn = qtests.stubMethod(log, 'warn', () => { warned = true; });
   let limit; //will capture clamped limit
   try {
     const qerrors = reloadQerrors(); //reload module with large limit
+    await new Promise(r => setImmediate(r)); //allow async warn callback
     limit = qerrors.getAdviceCacheLimit(); //fetch clamped limit value
   } finally {
     restoreWarn(); //restore logger warn

--- a/test/configFunctions.test.js
+++ b/test/configFunctions.test.js
@@ -1,0 +1,78 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+
+function withEnv(vars) {
+  const orig = {};
+  Object.entries(vars).forEach(([k, v]) => { orig[k] = process.env[k]; if (v === undefined) { delete process.env[k]; } else { process.env[k] = v; } });
+  return () => { Object.entries(orig).forEach(([k, v]) => { if (v === undefined) { delete process.env[k]; } else { process.env[k] = v; } }); };
+}
+
+function reloadConfig() {
+  delete require.cache[require.resolve('../lib/config')];
+  return require('../lib/config');
+}
+
+// Scenario: getEnv returns environment variable when set
+test('getEnv returns env var when present', () => {
+  const restore = withEnv({ TEST_VAL: 'xyz' });
+  const cfg = reloadConfig();
+  try {
+    assert.equal(cfg.getEnv('TEST_VAL'), 'xyz');
+  } finally { restore(); }
+});
+
+// Scenario: getEnv falls back to default when undefined
+test('getEnv falls back to default', () => {
+  const restore = withEnv({ QERRORS_QUEUE_LIMIT: undefined });
+  const cfg = reloadConfig();
+  try {
+    assert.equal(cfg.getEnv('QERRORS_QUEUE_LIMIT'), '100');
+  } finally { restore(); }
+});
+
+// Scenario: safeRun returns function result
+test('safeRun returns result', () => {
+  const cfg = reloadConfig();
+  const res = cfg.safeRun('fn', () => 5, 0);
+  assert.equal(res, 5);
+});
+
+// Scenario: safeRun catches error and returns fallback
+test('safeRun returns fallback on error', () => {
+  const cfg = reloadConfig();
+  let msg;
+  const restoreErr = qtests.stubMethod(console, 'error', m => { msg = m; });
+  try {
+    const out = cfg.safeRun('fn', () => { throw new Error('boom'); }, 7, 'info');
+    assert.equal(out, 7);
+    assert.ok(msg.includes('fn failed'));
+  } finally { restoreErr(); }
+});
+
+// Scenario: getInt parses env value
+test('getInt parses integer env value', () => {
+  const restore = withEnv({ QERRORS_TIMEOUT: '9000' });
+  const cfg = reloadConfig();
+  try {
+    assert.equal(cfg.getInt('QERRORS_TIMEOUT'), 9000);
+  } finally { restore(); }
+});
+
+// Scenario: getInt falls back to default on invalid env
+test('getInt uses default when env invalid', () => {
+  const restore = withEnv({ QERRORS_TIMEOUT: 'abc' });
+  const cfg = reloadConfig();
+  try {
+    assert.equal(cfg.getInt('QERRORS_TIMEOUT'), 10000);
+  } finally { restore(); }
+});
+
+// Scenario: getInt enforces minimum value
+test('getInt enforces minimum bound', () => {
+  const restore = withEnv({ QERRORS_TIMEOUT: '1' });
+  const cfg = reloadConfig();
+  try {
+    assert.equal(cfg.getInt('QERRORS_TIMEOUT', 5), 5);
+  } finally { restore(); }
+});

--- a/test/loggerFunctions.test.js
+++ b/test/loggerFunctions.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stubbing util
+
+const loggerPromise = require('../lib/logger');
+const { logStart, logReturn } = require('../lib/logger');
+
+// Scenario: logStart logs start message
+
+test('logStart logs function start', async () => {
+  const log = await loggerPromise;
+  let msg;
+  const restore = qtests.stubMethod(log, 'info', m => { msg = m; });
+  try {
+    await logStart('fn', { a: 1 });
+  } finally { restore(); }
+  assert.equal(msg, 'fn start {"a":1}');
+});
+
+// Scenario: logReturn logs return message
+
+test('logReturn logs function return', async () => {
+  const log = await loggerPromise;
+  let msg;
+  const restore = qtests.stubMethod(log, 'info', m => { msg = m; });
+  try {
+    await logReturn('fn', { b: 2 });
+  } finally { restore(); }
+  assert.equal(msg, 'fn return {"b":2}');
+});


### PR DESCRIPTION
## Summary
- provide escape-html stub for offline tests
- fix cache limit warning to await logger
- update analyzeError test for gpt-4o model
- fix cache limit warning test
- add tests for config helpers
- add tests for logger helpers
- add tests for cleanup intervals and metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68491ca4a8ac8322b4f4bb5491fa5110