### PR TITLE
Add verboseLog tests

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,7 @@ const defaults = { //default environment variable values for all qerrors configu
   QERRORS_LOG_MAXSIZE: String(1024 * 1024), //log file size in bytes
   QERRORS_LOG_MAXFILES: '5', //number of rotated log files
   QERRORS_LOG_MAX_DAYS: '0', //days to retain rotated logs //(0 disables time rotation)
-  QERRORS_VERBOSE: 'true', //enable verbose console logs
+  QERRORS_VERBOSE: 'false', //default off so unset env won't spam console
   QERRORS_LOG_DIR: 'logs', //directory for rotated logs
   QERRORS_DISABLE_FILE_LOGS: '', //flag to disable file transports when set
   QERRORS_SERVICE_NAME: 'qerrors', //service identifier for logger //(new default)

--- a/test/verboseLog.test.js
+++ b/test/verboseLog.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test'); //node test runner
+const assert = require('node:assert/strict'); //assert helpers
+const qtests = require('qtests'); //stub utility
+const { analyzeError } = require('../lib/qerrors'); //function under test
+
+function runAnalyze() {
+  const err = new Error('v');
+  err.name = 'AxiosError'; //trigger early return path
+  return analyzeError(err, 'ctx');
+}
+
+test('verboseLog uses console when QERRORS_VERBOSE=true', async () => {
+  const orig = process.env.QERRORS_VERBOSE; //save original env
+  process.env.QERRORS_VERBOSE = 'true'; //enable verbose output
+  let logged = false; //track console.log usage
+  const restore = qtests.stubMethod(console, 'log', () => { logged = true; });
+  try {
+    await runAnalyze(); //invoke analyzeError which calls verboseLog
+    assert.equal(logged, true); //expect console.log called
+  } finally {
+    restore(); //restore stubbed log
+    if (orig === undefined) { delete process.env.QERRORS_VERBOSE; } else { process.env.QERRORS_VERBOSE = orig; } //restore env
+  }
+});
+
+test('verboseLog skips console when QERRORS_VERBOSE=false', async () => {
+  const orig = process.env.QERRORS_VERBOSE; //store env
+  process.env.QERRORS_VERBOSE = 'false'; //disable verbose output
+  let logged = false; //track calls
+  const restore = qtests.stubMethod(console, 'log', () => { logged = true; });
+  try {
+    await runAnalyze(); //run analyzeError with verbose disabled
+    assert.equal(logged, false); //console.log should not run
+  } finally {
+    restore(); //cleanup stub
+    if (orig === undefined) { delete process.env.QERRORS_VERBOSE; } else { process.env.QERRORS_VERBOSE = orig; } //reset env
+  }
+});
+
+test('verboseLog skips console when QERRORS_VERBOSE unset', async () => {
+  const orig = process.env.QERRORS_VERBOSE; //capture original value
+  delete process.env.QERRORS_VERBOSE; //unset variable
+  let logged = false; //track usage
+  const restore = qtests.stubMethod(console, 'log', () => { logged = true; });
+  try {
+    await runAnalyze(); //execute analyzeError
+    assert.equal(logged, false); //expect no console output
+  } finally {
+    restore(); //restore stub
+    if (orig === undefined) { delete process.env.QERRORS_VERBOSE; } else { process.env.QERRORS_VERBOSE = orig; } //restore value
+  }
+});


### PR DESCRIPTION
## Summary
- test verboseLog console logging behavior
- default verbose output to false so unset env doesn't spam console

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849294646108322866a233a14392dd7