### PR TITLE
Update README default

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ qerrors reads several environment variables to tune its behavior. A small config
 * `QERRORS_LOG_MAXSIZE` &ndash; logger rotation size in bytes (default `1048576`).
 * `QERRORS_LOG_MAXFILES` &ndash; number of rotated log files (default `5`).
   * `QERRORS_LOG_MAX_DAYS` &ndash; days to retain daily logs (default `0`). A value of `0` keeps all logs forever and emits a startup warning; set a finite number in production to manage disk usage. //(document startup warning behavior)
-* `QERRORS_VERBOSE` &ndash; enable console logging (`true` by default). Set `QERRORS_VERBOSE=false` for production deployments to keep logs from flooding the console and rely on file output instead.
+* `QERRORS_VERBOSE` &ndash; enable console logging (`false` by default). Set `QERRORS_VERBOSE=false` for production deployments to keep logs from flooding the console and rely on file output instead.
 * `QERRORS_LOG_DIR` &ndash; directory for logger output (default `logs`).
 * `QERRORS_DISABLE_FILE_LOGS` &ndash; disable file transports when set.
 * `QERRORS_LOG_LEVEL` &ndash; logger output level (default `info`). //(document log level)


### PR DESCRIPTION
## Summary
- document the correct default for `QERRORS_VERBOSE`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684936be5ca883229cf16a5cd8346bc3