### PR TITLE
Fix log dir failure state & add mkdir test

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -74,7 +74,7 @@ async function initLogDir() { //prepare log directory asynchronously ensuring pr
 async function buildLogger() { //(create logger after directory preparation complete)
         await initLogDir(); //(ensure directory exists before configuring file transports)
         const maxDays = Number(process.env.QERRORS_LOG_MAX_DAYS) || 0; //days to retain logs //(calculate dynamically to respect env changes)
-        disableFileLogs = !!process.env.QERRORS_DISABLE_FILE_LOGS; //(refresh file log state to respect env changes)
+        disableFileLogs = disableFileLogs || !!process.env.QERRORS_DISABLE_FILE_LOGS; //(preserve directory failure flag while applying env override)
         const DailyRotateFile = require('winston-daily-rotate-file'); //(load dynamically to ensure test stubs work)
        const log = createLogger({ //(build configured winston logger instance with multi-transport setup)
         level: config.getEnv('QERRORS_LOG_LEVEL'), //(log level from env variable defaulting to 'info' for errors, warnings, and info messages)


### PR DESCRIPTION
## Summary
- preserve disableFileLogs when initLogDir fails
- test console-only logger on mkdir failure
- update daily rotate test for stub `opts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849bf88ba308322b02ac1999ba46ac4