### PR TITLE
Ensure context is stringified before analysis

### DIFF
--- a/lib/qerrors.js
+++ b/lib/qerrors.js
@@ -226,10 +226,10 @@ async function postWithRetry(url, data, opts, capMs) { //post wrapper with retry
  * - Max tokens=2048 balances detail with cost considerations
  * 
  * @param {Error} error - The error object containing name, message, and stack trace
- * @param {string} context - Contextual information about where/when the error occurred
+ * @param {string} contextString - Contextual information already stringified by qerrors
  * @returns {Promise<Object|null>} - AI-generated advice object or null if analysis fails or is skipped for Axios errors //(update return description)
  */
-async function analyzeError(error, context) {
+async function analyzeError(error, contextString) {
         if (typeof error.name === 'string' && error.name.includes('AxiosError')) { //(skip axios error objects early to prevent infinite loops when our API calls fail)
                 verboseLog(`Axios Error`); //(log axios detection for analysis skip)
                 return null; //(avoid API call when axios error encountered)
@@ -238,7 +238,7 @@ async function analyzeError(error, context) {
         verboseLog(`qerrors error analysis is running for
                         error name: "${error.uniqueErrorName}",
                         error message: "${error.message}",
-                        with context: "${context}"`); //(log analysis attempt for debugging, multi-line format improves console readability)
+                        with context: "${contextString}"`); //(log analysis attempt for debugging with pre-stringified context)
 
         if (ADVICE_CACHE_LIMIT !== 0 && !error.qerrorsKey) { //generate hash key when caching
                 error.qerrorsKey = crypto.createHash('sha256').update(`${error.message}${error.stack}`).digest('hex'); //create cache key from message and stack
@@ -261,7 +261,7 @@ async function analyzeError(error, context) {
         const errorPrompt = `Analyze this error and provide debugging advice. You must respond with a valid JSON object containing an "advice" field with a concise solution:
 
 Error: ${error.name} - ${error.message}
-Context: ${context}
+Context: ${contextString}
 Stack: ${truncatedStack}`; //(JSON format prompt for structured response with explicit instruction)
         
         // OpenAI API call with optimized parameters for error analysis
@@ -298,7 +298,7 @@ Stack: ${truncatedStack}`; //(JSON format prompt for structured response with ex
                 verboseLog(`qerrors is returning advice for
                                 the error name: "${error.uniqueErrorName}",
                                 with the error message: "${error.message}",
-                                with context: "${context}"`); //(log successful advice return for debugging)
+                                with context: "${contextString}"`); //(log successful advice return with pre-stringified context)
                 
                 //(cache and return the parsed advice object directly)
                 verboseLog(`${error.uniqueErrorName} ${JSON.stringify(advice)}`); //(stringify advice for consistent logging)
@@ -324,7 +324,7 @@ Stack: ${truncatedStack}`; //(JSON format prompt for structured response with ex
  * - Implements defensive programming to prevent secondary errors
  * 
  * @param {Error} error - The error object to process
- * @param {string} context - Descriptive context about where/when error occurred
+ * @param {string|Object} context - Descriptive context about where/when error occurred; objects are JSON stringified
  * @param {Object} [req] - Express request object (optional, enables middleware features)
  * @param {Object} [res] - Express response object (optional, enables automatic responses)
  * @param {Function} [next] - Express next function (optional, enables middleware chaining)
@@ -337,10 +337,11 @@ async function qerrors(error, context, req, res, next) {
                 console.warn('qerrors called without an error object');
                 return;
         }
-        
+
         // Context defaulting ensures we always have meaningful error context
         // This helps with debugging and error correlation across logs
         context = context || 'unknown context';
+        const contextString = typeof context === 'string' ? context : JSON.stringify(context); //normalize context for logging and analysis
         
         // Generate unique error identifier for tracking and correlation
         // Format: "ERROR: " + errorType + timestamp + randomString
@@ -350,7 +351,7 @@ async function qerrors(error, context, req, res, next) {
         // Log error processing start with full context
         // Multi-line format improves readability in log aggregation systems
         verboseLog(`qerrors is running for error message: "${error.message}",
-                        with context: "${context}",
+                        with context: "${contextString}",
                         assigning it the unique error name: "${uniqueErrorName}"`);
         
         // Generate ISO timestamp for consistent log timing across time zones
@@ -375,7 +376,7 @@ async function qerrors(error, context, req, res, next) {
                 message, // Human-readable error description
                 statusCode, // HTTP status for web context
                 isOperational, // Distinguishes expected vs unexpected errors
-                context, // Contextual information for debugging
+                context: contextString, // Contextual information for debugging now stringified
                 stack: error.stack // Full stack trace for technical debugging
         };
         
@@ -427,7 +428,7 @@ async function qerrors(error, context, req, res, next) {
         }
 
         Promise.resolve() //(start async analysis without blocking response to maintain fast error handling)
-                .then(() => scheduleAnalysis(error, context)) //(invoke queued analysis after sending response to prevent delays)
+                .then(() => scheduleAnalysis(error, contextString)) //(invoke queued analysis after sending response with context string)
                 .catch(async (analysisErr) => (await logger).error(analysisErr)); //(log any scheduleAnalysis failures to prevent silent errors)
 
         verboseLog(`qerrors ran`); //(log completion after scheduling analysis for debugging flow)


### PR DESCRIPTION
## Summary
- stringify the context in `qerrors` before logging and analyzing
- adapt `analyzeError` to accept the pre-stringified context
- test that object contexts are JSON stringified when sent to OpenAI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849dfab4cac83228dddd981d6a65084