### PR TITLE
Fix stub options property for tests

### DIFF
--- a/stubs/winston-daily-rotate-file.js
+++ b/stubs/winston-daily-rotate-file.js
@@ -1,6 +1,6 @@
 class DailyRotateFile {
   constructor(opts) {
-    this.opts = opts; //store options for test verification
+    this.options = opts; //expose options like real module for tests
     // Use global tracking to ensure all instances are captured
     if (!global.DailyRotateFileCalls) global.DailyRotateFileCalls = [];
     global.DailyRotateFileCalls.push(opts);


### PR DESCRIPTION
## Summary
- expose `.options` on winston-daily-rotate-file stub to mirror real API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849fdc4de1083229833a63026c31d4b